### PR TITLE
Update js-md5 to v0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/imgix-core-js.js",
   "dependencies": {
-    "js-md5": "^0.3.0",
+    "js-md5": "^0.4.0",
     "js-base64": "^2.1.9"
   },
   "devDependencies": {


### PR DESCRIPTION
When running in a certain server runtimes v0.3.0 makes the assertion
that the `navigator` option is available on the global scope resulting
in the error `Cannot read property 'navigator' of undefined`.

This appears to be fixed in v0.4.

The offending line can be found here: https://github.com/emn178/js-md5/blob/v0.3.0/src/md5.js#L20