### PR TITLE
Improve `ImgixClient._sanitizePath()`

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -63,17 +63,23 @@
     };
 
     ImgixClient.prototype._sanitizePath = function(path) {
-      if (path.indexOf('http') === 0) {
+      // Strip leading slash first (we'll re-add after encoding)
+      path = path.replace(/^\//, '');
+
+      // Decode the path, since we don't know whether it's pre-encoded
+      path = decodeURIComponent(path);
+
+      if (/^https?:\/\//.test(path)) {
+        // Use encodeURIComponent if we think the path is a full URL,
+        // since it encodes all characters
         path = encodeURIComponent(path);
       } else {
+        // Use encodeURI if we think the path is just a path,
+        // so it leaves legal characters like '/' and '@' alone
         path = encodeURI(path);
       }
 
-      if (path[0] !== '/') {
-        path = "/" + path;
-      }
-
-      return path;
+      return '/' + path;
     };
 
     ImgixClient.prototype._buildParams = function(params) {

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -122,6 +122,16 @@ describe('Client', function() {
       assert.equal(url, "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534");
     });
 
+    it('encodes a fully-qualified HTTPS URL with parameters and a signature', function() {
+      var url = signedClient.buildURL('https://avatars.com/john-smith.png', { w: 400, h: 300 });
+      assert.equal(url, "https://my-social-network.imgix.net/https%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=7fb92b2af2526019d64ec26465388533");
+    });
+
+    it('encodes a fully-qualified URL with parameters and a signature, even when the path contains a leading slash', function() {
+      var url = signedClient.buildURL('/http://avatars.com/john-smith.png', { w: 400, h: 300 });
+      assert.equal(url, "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534");
+    });
+
     it('URL encodes param keys', function() {
       var url = unsignedClient.buildURL('demo.png', { 'hello world': 'interesting' });
       assert.equal(url, 'https://my-source.imgix.net/demo.png?hello%20world=interesting');


### PR DESCRIPTION
This PR makes a few improvements to the `ImgixClient._sanitizePath()` method:

- If a full URL was passed in to the method with a leading slash, it was being treated like a relative path and wasn't being encoded properly. This has been fixed so any leading slash gets stripped before evaluating the given path for encoding purposes, then re-added before return.

- The method now gracefully handles both paths that are passed in both pre-encoded and unencoded by passing the given path through `decodeURIComponent()` up front. As far as my brain is able to imagine, this should be a perfectly safe procedure. The result is that paths passed in un-encoded get decoded (resulting in the exact same string) and then encoded, and paths that are passed in encoded get decoded and then re-encoded. 

- Previously the method would naively treat any path starting with `http` as a fully-qualified URL. This has been fixed by changing the test to `if (/^https?:\/\//.test(path)) { ... }` instead.

Note that these changes make the method about 50% slower: https://jsperf.com/imgix-core-js-sanitizepath/1. That's not to say the method runs slowly now: even at its new slower rate, it's still running in hundreds of thousandths of a second. 