### PR TITLE
Rework de/encoding in `_sanitizePath` method to be more careful

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -66,17 +66,19 @@
       // Strip leading slash first (we'll re-add after encoding)
       path = path.replace(/^\//, '');
 
-      // Decode the path, since we don't know whether it's pre-encoded
-      path = decodeURIComponent(path);
-
       if (/^https?:\/\//.test(path)) {
-        // Use encodeURIComponent if we think the path is a full URL,
-        // since it encodes all characters
+        // Use de/encodeURIComponent to ensure *all* characters are handled,
+        // since it's being used as a path
         path = encodeURIComponent(path);
+      } else if (/^https?%3A%2F%2F/.test(path)) {
+        // Decode and re-encode the path, to ensure that it's fully, correctly encoded.
+        // Use de/encodeURIComponent to ensure *all* characters are handled,
+        // since it's being used as a path
+        path = decodeURIComponent(encodeURIComponent(path));
       } else {
-        // Use encodeURI if we think the path is just a path,
+        // Use de/encodeURI if we think the path is just a path,
         // so it leaves legal characters like '/' and '@' alone
-        path = encodeURI(path);
+        path = decodeURI(encodeURI(path));
       }
 
       return '/' + path;

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -32,121 +32,316 @@ describe('Client', function() {
     });
   });
 
-  describe('#buildURL', function() {
-    var signedClient = new ImgixClient({
-      host: 'my-social-network.imgix.net',
-      secureURLToken: 'FOO123bar',
-      includeLibraryParam: false
+  describe('Calling _sanitizePath()', function describeSuite() {
+    var client;
+
+    beforeEach(function setupClient() {
+      client = new ImgixClient({
+        host: 'testing.imgix.net'
+      });
     });
 
-    var unsignedClient = new ImgixClient({
-      host: 'my-source.imgix.net',
-      includeLibraryParam: false
-    });
+    describe('with a simple path', function describeSuite() {
+      var path = 'images/1.png';
 
-    it('tranforms to string correctly', function() {
-      assert.equal(signedClient.buildURL('/users/1.png'), "https://my-social-network.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c");
-    });
+      it('prepends a leading slash', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
 
-    it('transforms a fully-qualified URL', function() {
-      assert.equal(signedClient.buildURL('http://avatars.com/john-smith.png', { w: 400, h: 300 }), "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534");
-    });
-
-    it('includes the `ixlib` parameter', function() {
-      var testClient = new ImgixClient({
-        host: 'my-social-network.imgix.net',
-        secureURLToken: 'FOO123bar'
+        assert.equal(expectation, result.substr(0, 1));
       });
 
-      assert.ok(testClient.buildURL('/users/1.png').search(/ixlib=js-\d+\.\d+\.\d+/) > -1);
+      it('otherwise returns the same exact path', function testSpec() {
+        var expectation = path,
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
     });
 
-    it('does not include the `ixlib` parameter', function() {
-      var testClient = new ImgixClient({
-        host: 'my-social-network.imgix.net',
-        secureURLToken: 'FOO123bar',
+    describe('with a path that contains a leading slash', function describeSuite() {
+      var path = '/images/1.png';
+
+      it('retains the leading slash', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns the same exact path', function testSpec() {
+        var expectation = path.substr(1),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a path that includes encoded characters', function describeSuite() {
+      var path = 'images/image%201.png';
+
+      it('prepends a leading slash', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns the same exact path, maintaining proper encoding', function testSpec() {
+        var expectation = path,
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a full HTTP URL', function describeSuite() {
+      var path = 'http://example.com/images/1.png';
+
+      it('prepends a leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
+        var expectation = encodeURIComponent(path),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a full HTTPS URL', function describeSuite() {
+      var path = 'https://example.com/images/1.png';
+
+      it('prepends a leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
+        var expectation = encodeURIComponent(path),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a full URL that contains a leading slash', function describeSuite() {
+      var path = '/http://example.com/images/1.png';
+
+      it('retains the leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
+        var expectation = encodeURIComponent(path.substr(1)),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a full URL that contains encoded characters', function describeSuite() {
+      var path = 'http://example.com/images/1.png?foo=%20';
+
+      it('prepends a leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
+        var expectation = encodeURIComponent(path),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+
+      it('double-encodes the original encoded characters', function testSpec() {
+        var expectation1 = -1,
+            expectation2 = encodeURIComponent(path).length - 4;
+            result = client._sanitizePath(path);
+
+        // Result should not contain the string "%20"
+        assert.equal(expectation1, result.indexOf('%20'));
+
+        // Result should instead contain the string "%2520"
+        assert.equal(expectation2, result.indexOf('%2520'));
+      });
+    });
+
+    describe('with a pre-encoded full HTTP URL', function describeSuite() {
+      var path = encodeURIComponent('http://example.com/images/1.png');
+
+      it('prepends a leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns the given URL, still encoded', function testSpec() {
+        var expectation = path,
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a pre-encoded full HTTPS URL', function describeSuite() {
+      var path = encodeURIComponent('https://example.com/images/1.png');
+
+      it('prepends a leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns the given URL, still encoded', function testSpec() {
+        var expectation = path,
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+
+    describe('with a pre-encoded full URL that contains a leading slash', function describeSuite() {
+      var path = '/' + encodeURIComponent('http://example.com/images/1.png');
+
+      it('retains the leading slash, unencoded', function testSpec() {
+        var expectation = '/',
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(0, 1));
+      });
+
+      it('otherwise returns the given URL, still encoded', function testSpec() {
+        var expectation = path.substr(1),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substr(1));
+      });
+    });
+  });
+
+  describe('Calling _buildParams()', function describeSuite() {
+    var client;
+
+    beforeEach(function setupClient() {
+      client = new ImgixClient({
+        host: 'testing.imgix.net',
         includeLibraryParam: false
       });
-
-      assert.ok(testClient.buildURL('/users/1.png').search(/ixlib=js-\d+\.\d+\.\d+/) === -1);
     });
 
-    it('transforms to string correctly', function() {
-      var url = unsignedClient.buildURL('/path/to/image.png');
-      assert.equal(url, "https://my-source.imgix.net/path/to/image.png");
+    it('returns an empty string if no parameters are given', function testSpec() {
+      var params = {},
+          expectation = '',
+          result = client._buildParams(params);
+
+      assert.equal(expectation, result);
     });
 
-    it('adds a leading slash', function() {
-      var url = unsignedClient.buildURL('path/to/image.png');
-      assert.equal(url, "https://my-source.imgix.net/path/to/image.png");
+    it('returns a properly-formatted query string if a single parameter is given', function testSpec() {
+      var params = {
+              w: 400
+            },
+          expectation = '?w=400',
+          result = client._buildParams(params);
+
+      assert.equal(expectation, result);
     });
 
-    it('creates an insecure string correctly', function() {
-      var testClient = new ImgixClient({
-        host: 'my-source.imgix.net',
-        includeLibraryParam: false,
-        useHTTPS: false
+    it('returns a properly-formatted query string if multiple parameters are given', function testSpec() {
+      var params = {
+              w: 400,
+              h: 300
+            },
+          expectation = '?w=400&h=300',
+          result = client._buildParams(params);
+
+      assert.equal(expectation, result);
+    });
+
+    it('includes an `ixlib` param if the `libraryParam` setting is truthy', function testSpec() {
+      var params = {
+              w: 400
+            },
+          expectation = '?w=400&ixlib=test',
+          result;
+
+      client.settings.libraryParam = 'test';
+
+      result = client._buildParams(params);
+
+      assert.equal(expectation, result);
+    });
+
+    it('url-encodes parameter keys properly', function testSpec() {
+      var params = {
+              'w$': 400
+            },
+          expectation = '?w%24=400',
+          result = client._buildParams(params);
+
+      assert.equal(expectation, result);
+    });
+
+    it('url-encodes parameter values properly', function testSpec() {
+      var params = {
+              w: '$400'
+            },
+          expectation = '?w=%24400',
+          result = client._buildParams(params);
+
+      assert.equal(expectation, result);
+    });
+
+    it('base64-encodes parameter values whose keys end in `64`', function testSpec() {
+      var params = {
+              txt64: 'lorem ipsum'
+            },
+          expectation = '?txt64=bG9yZW0gaXBzdW0',
+          result = client._buildParams(params);
+
+      assert.equal(expectation, result);
+    });
+  });
+
+  describe('Calling _signParams()', function describeSuite() {
+    var client,
+        path = 'images/1.png';
+
+    beforeEach(function setupClient() {
+      client = new ImgixClient({
+        host: 'testing.imgix.net',
+        secureURLToken: 'MYT0KEN',
+        includeLibraryParam: false
       });
-
-      var url = testClient.buildURL('/path/to/image.png');
-      assert.equal(url, "http://my-source.imgix.net/path/to/image.png");
     });
 
-    it('encodes with a space in path correctly', function() {
-      var url = signedClient.buildURL('/users/image 1.png');
-      assert.equal(url, "https://my-social-network.imgix.net/users/image%201.png?s=193462f12470fe53927d0cf21e07d404");
+    it('returns a query string containing only a proper signature parameter, if no other query parameters are provided', function testSpec() {
+      var expectation = '?s=6d82410f89cc6d80a6aa9888dcf85825',
+          result = client._signParams(path, '');
+
+      assert.equal(expectation, result);
     });
 
-    it('encodes with a token correctly', function() {
-      var url = signedClient.buildURL('/users/1.png');
-      assert.equal(url, "https://my-social-network.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c");
-    });
+    it('returns a query string with a proper signature parameter appended, if other query parameters are provided', function testSpec() {
+      var expectation = '?w=400&s=990916ef8cc640c58d909833e47f6c31',
+          result = client._signParams(path, '?w=400');
 
-    it('encodes a fully-qualified URL correctly', function() {
-      var url = signedClient.buildURL('http://avatars.com/john-smith.png');
-      assert.equal(url, "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?s=493a52f008c91416351f8b33d4883135");
-    });
-
-    it('encodes a fully-qualified URL with spaces in path correctly', function() {
-      var url = signedClient.buildURL('http://awebsite.com/users dir/image 1.png');
-      assert.equal(url, "https://my-social-network.imgix.net/http%3A%2F%2Fawebsite.com%2Fusers%20dir%2Fimage%201.png?s=a82cd70cc2b2edae1fd0d83fc86e7884");
-    });
-
-    it('encodes a simple path with parameters and a signature', function() {
-      var url = signedClient.buildURL('/users/1.png', { w: 400, h: 300 });
-      assert.equal(url, "https://my-social-network.imgix.net/users/1.png?w=400&h=300&s=c7b86f666a832434dd38577e38cf86d1");
-    });
-
-    it('encodes a fully-qualified URL with parameters and a signature', function() {
-      var url = signedClient.buildURL('http://avatars.com/john-smith.png', { w: 400, h: 300 });
-      assert.equal(url, "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534");
-    });
-
-    it('encodes a fully-qualified HTTPS URL with parameters and a signature', function() {
-      var url = signedClient.buildURL('https://avatars.com/john-smith.png', { w: 400, h: 300 });
-      assert.equal(url, "https://my-social-network.imgix.net/https%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=7fb92b2af2526019d64ec26465388533");
-    });
-
-    it('encodes a fully-qualified URL with parameters and a signature, even when the path contains a leading slash', function() {
-      var url = signedClient.buildURL('/http://avatars.com/john-smith.png', { w: 400, h: 300 });
-      assert.equal(url, "https://my-social-network.imgix.net/http%3A%2F%2Favatars.com%2Fjohn-smith.png?w=400&h=300&s=61ea1cc7add87653bb0695fe25f2b534");
-    });
-
-    it('URL encodes param keys', function() {
-      var url = unsignedClient.buildURL('demo.png', { 'hello world': 'interesting' });
-      assert.equal(url, 'https://my-source.imgix.net/demo.png?hello%20world=interesting');
-    });
-
-    it('URL encodes param values', function() {
-      var url = unsignedClient.buildURL('demo.png', { 'hello_world': '/foo"> <script>alert("hacked")</script><' });
-
-      assert.equal(url, 'https://my-source.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C');
-    });
-
-    it('Base64 encodes Base64 param variants', function() {
-      var url = unsignedClient.buildURL('~text', { 'txt64': 'I cannøt belîév∑ it wors! 😱' });
-
-      assert.equal(url, 'https://my-source.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE');
+      assert.equal(expectation, result);
     });
   });
 });

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -1,16 +1,16 @@
 var assert = require('assert');
 var ImgixClient = require('../src/imgix-core-js');
 
-describe('Client', function() {
-  describe('contstructor', function() {
-    it('initializes with correct defaults', function() {
+describe('Imgix client:', function describeSuite() {
+  describe('The constructor', function describeSuite() {
+    it('initializes with correct defaults', function testSpec() {
       var client = new ImgixClient({ host: 'my-host.imgix.net' });
       assert.equal("my-host.imgix.net", client.settings.host);
       assert.equal(null, client.settings.secureURLToken);
       assert.equal(true, client.settings.useHTTPS);
     });
 
-    it('initialized with a token', function() {
+    it('initializes with a token', function testSpec() {
       var client = new ImgixClient({
         host: 'my-host.imgix.net',
         secureURLToken: 'MYT0KEN'
@@ -20,7 +20,7 @@ describe('Client', function() {
       assert.equal(true, client.settings.useHTTPS);
     });
 
-    it('initialized in insecure mode', function() {
+    it('initializes in insecure mode', function testSpec() {
       var client = new ImgixClient({
         host: 'my-host.imgix.net',
         secureURLToken: 'MYT0KEN',


### PR DESCRIPTION
This PR is intended to fix the two issues brought up in #24, both of which involve encoding errors brought about by ham-fistedly decoding all paths fed in to the `_sanitizePath()` private method before attempting to re-encode things properly based on whether we determined the path was a fully qualified URL or just a path fragment.

Instead of this clumsy approach, we're now evaluating the given path up front to determine which of the following categories it falls into. Each category is then handled slightly differently:

- *Fully-qualified, unencoded URLs*. If the given path matches `/^https?:\/\//`, we assume its a fully-qualified, unencoded URL. All we need to do here is encode it as though it was a URI component (since it will be just a component, in the final imgix URL).
- *Fully-qualified, pre-encoded URLs*. If the given path matches `/^https?:%3A%2F%2F/`, we assume its a fully-qualified, pre-encoded URL. In this case, we decode and re-encode it using `decodeURIComponent` and `encodeURIComponent`, to ensure that all characters in the string are actually encoded properly.
- *Path fragments*. If the given path does not match either of the above patterns, we must assume that it's a boring path rather than a full URL. In this case, we decode and re-encode it as above, but this time we use `decodeURI` and `encodeURI` so that legal path characters such as `/` and `@` aren't affected.

This PR also reorganizes the library's tests so they're focused on the private component methods that make up the public `buildURL()` method: `_sanitizePath()`, `_buildParams()`, and `_signParams()`. Testing these component functions separately allows us to untangle the various cases that need to be tested and gives us better confidence that all cases are being covered.

@mchatman Do you mind giving this a quick review?