### PR TITLE
Remove "clever" decoding from `_sanitizePath`

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -70,15 +70,10 @@
         // Use de/encodeURIComponent to ensure *all* characters are handled,
         // since it's being used as a path
         path = encodeURIComponent(path);
-      } else if (/^https?%3A%2F%2F/.test(path)) {
-        // Decode and re-encode the path, to ensure that it's fully, correctly encoded.
-        // Use de/encodeURIComponent to ensure *all* characters are handled,
-        // since it's being used as a path
-        path = decodeURIComponent(encodeURIComponent(path));
       } else {
         // Use de/encodeURI if we think the path is just a path,
         // so it leaves legal characters like '/' and '@' alone
-        path = decodeURI(encodeURI(path));
+        path = encodeURI(path);
       }
 
       return '/' + path;

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -77,8 +77,8 @@ describe('Imgix client:', function describeSuite() {
       });
     });
 
-    describe('with a path that includes encoded characters', function describeSuite() {
-      var path = 'images/image%201.png';
+    describe('with a path that contains unencoded characters', function describeSuite() {
+      var path = 'images/"image 1".png';
 
       it('prepends a leading slash', function testSpec() {
         var expectation = '/',
@@ -87,8 +87,8 @@ describe('Imgix client:', function describeSuite() {
         assert.equal(expectation, result.substr(0, 1));
       });
 
-      it('otherwise returns the same exact path, maintaining proper encoding', function testSpec() {
-        var expectation = path,
+      it('otherwise returns the same path, except with the characters encoded properly', function testSpec() {
+        var expectation = encodeURI(path),
             result = client._sanitizePath(path);
 
         assert.equal(expectation, result.substr(1));
@@ -176,60 +176,6 @@ describe('Imgix client:', function describeSuite() {
 
         // Result should instead contain the string "%2520"
         assert.equal(expectation2, result.indexOf('%2520'));
-      });
-    });
-
-    describe('with a pre-encoded full HTTP URL', function describeSuite() {
-      var path = encodeURIComponent('http://example.com/images/1.png');
-
-      it('prepends a leading slash, unencoded', function testSpec() {
-        var expectation = '/',
-            result = client._sanitizePath(path);
-
-        assert.equal(expectation, result.substr(0, 1));
-      });
-
-      it('otherwise returns the given URL, still encoded', function testSpec() {
-        var expectation = path,
-            result = client._sanitizePath(path);
-
-        assert.equal(expectation, result.substr(1));
-      });
-    });
-
-    describe('with a pre-encoded full HTTPS URL', function describeSuite() {
-      var path = encodeURIComponent('https://example.com/images/1.png');
-
-      it('prepends a leading slash, unencoded', function testSpec() {
-        var expectation = '/',
-            result = client._sanitizePath(path);
-
-        assert.equal(expectation, result.substr(0, 1));
-      });
-
-      it('otherwise returns the given URL, still encoded', function testSpec() {
-        var expectation = path,
-            result = client._sanitizePath(path);
-
-        assert.equal(expectation, result.substr(1));
-      });
-    });
-
-    describe('with a pre-encoded full URL that contains a leading slash', function describeSuite() {
-      var path = '/' + encodeURIComponent('http://example.com/images/1.png');
-
-      it('retains the leading slash, unencoded', function testSpec() {
-        var expectation = '/',
-            result = client._sanitizePath(path);
-
-        assert.equal(expectation, result.substr(0, 1));
-      });
-
-      it('otherwise returns the given URL, still encoded', function testSpec() {
-        var expectation = path.substr(1),
-            result = client._sanitizePath(path);
-
-        assert.equal(expectation, result.substr(1));
       });
     });
   });


### PR DESCRIPTION
I had previously updated the `ImgixClient._sanitizePath()` method in an attempt to be clever and properly handle pre-encoded paths. This introduced unnecessary complexity into the method (detemining whether or not a given string is unencoded, sorta pre-encoded, or fully pre-encoded is trickier than it seems at first glance) and introduced stupid bugs into its base use-case.

Having failed my attempt at cleverness, I am suitably chagrined. This PR removes all code dealing with pre-encoded paths from `ImgixClient._sanitizePath()` so it only handle non-encoded inputs. Our README has instructed users to only pass in non-encoded data from the start:

> Whenever you provide data to imgix-core-js, make sure it is not already URL-encoded, as the library handles proper encoding internally.

This also fixes #28, and includes a new test case to ensure non-URL paths with spaces are handled properly. 

@oaleynik Would you care to review these changes for me?