### PR TITLE
Fixed Base64 issue when define is defined

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -11,7 +11,7 @@
   }
 })(this, function (exports, _md5, _jsBase64) {
   var md5 = _md5;
-  var Base64 = _jsBase64;
+  var Base64 = _jsBase64.Base64 || _jsBase64;
 
   var VERSION = '1.1.0';
   var DEFAULTS = {


### PR DESCRIPTION
Fixed an issue with Base64 encoding when ImgixClient is initialized from the first case, i.e.
if (typeof define === 'function' && define.amd) {
    define('Imgix', ['exports', 'md5', 'js-base64'], factory);