### PR TITLE
Add domain validation during ImgixClient initialization

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "homepage": "https://github.com/imgix/imgix-core-js",
   "authors": [
     "Kelly Sutton <michael.k.sutton@gmail.com>",
-    "Paul Straw <paulstraw@paulstraw.com>"
+    "Paul Straw <paulstraw@paulstraw.com>",
+    "Sherwin Heydarbeygi <sherwin@imgix.com>"
   ],
   "main": "dist/imgix-core-js.js",
   "description": "Common boilerplate for all imgix JavaScript-based functionality.",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,8 @@
+const domainRegex = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i;
+
+module.exports = {
+    VERSION:'1.2.0',
+    SHARD_STRATEGY_CRC:'crc',
+    SHARD_STRATEGY_CYCLE:'cycle',
+    DOMAIN_REGEX: domainRegex,
+}

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -1,3 +1,5 @@
+var constants = require("../src/constants.js");
+
 (function (global, factory) {
   if (typeof define === 'function' && define.amd) {
     define('Imgix', ['exports', 'md5', 'js-base64', 'crc'], factory);
@@ -14,15 +16,12 @@
   var Base64 = _jsBase64.Base64 || _jsBase64;
   var crc = _crc;
 
-  var VERSION = '1.2.0';
-  var SHARD_STRATEGY_CRC = 'crc';
-  var SHARD_STRATEGY_CYCLE = 'cycle';
   var DEFAULTS = {
     host: null,
     domains: [],
     useHTTPS: true,
     includeLibraryParam: true,
-    shard_strategy: SHARD_STRATEGY_CRC
+    shard_strategy: constants.SHARD_STRATEGY_CRC
   };
 
   var ImgixClient = (function() {
@@ -50,10 +49,10 @@
         throw new Error('ImgixClient must be passed valid domain(s)');
       }
 
-      if (this.settings.shard_strategy !== SHARD_STRATEGY_CRC
-          && this.settings.shard_strategy !== SHARD_STRATEGY_CYCLE) {
+      if (this.settings.shard_strategy !== constants.SHARD_STRATEGY_CRC
+          && this.settings.shard_strategy !== constants.SHARD_STRATEGY_CYCLE) {
         throw new Error('Shard strategy must be one of ' +
-          SHARD_STRATEGY_CRC + ' or ' + SHARD_STRATEGY_CYCLE);
+          constants.SHARD_STRATEGY_CRC + ' or ' + constants.SHARD_STRATEGY_CYCLE);
       }
 
       if (this.settings.host) {
@@ -62,8 +61,17 @@
           this.settings.domains[0] = this.settings.host;
       }
 
+      this.settings.domains.forEach(function(domain) {
+        if (constants.DOMAIN_REGEX.exec(domain) == null) {
+          throw new Error(
+            'Domains must be passed in as fully-qualified ' + 
+            'domain names and should not include a protocol or any path ' + 
+            'element, i.e. "example.imgix.net".');
+        }
+      });
+
       if (this.settings.includeLibraryParam) {
-        this.settings.libraryParam = "js-" + VERSION;
+        this.settings.libraryParam = "js-" + constants.VERSION;
       }
 
       this.settings.urlPrefix = this.settings.useHTTPS ? 'https://' : 'http://'
@@ -85,12 +93,12 @@
     };
 
     ImgixClient.prototype._getDomain = function(path) {
-      if (this.settings.shard_strategy === SHARD_STRATEGY_CYCLE) {
+      if (this.settings.shard_strategy === constants.SHARD_STRATEGY_CYCLE) {
         var domain = this.settings.domains[this._shard_next_index];
         this._shard_next_index = (this._shard_next_index + 1) % this.settings.domains.length;
         return domain;
       }
-      else if (this.settings.shard_strategy === SHARD_STRATEGY_CRC) {
+      else if (this.settings.shard_strategy === constants.SHARD_STRATEGY_CRC) {
         return this.settings.domains[crc.crc32(path) % this.settings.domains.length];
       }
     }
@@ -149,9 +157,9 @@
       }
     };
 
-    ImgixClient.VERSION = VERSION;
-    ImgixClient.SHARD_STRATEGY_CRC = SHARD_STRATEGY_CRC;
-    ImgixClient.SHARD_STRATEGY_CYCLE = SHARD_STRATEGY_CYCLE;
+    ImgixClient.VERSION = constants.VERSION;
+    ImgixClient.SHARD_STRATEGY_CRC = constants.SHARD_STRATEGY_CRC;
+    ImgixClient.SHARD_STRATEGY_CYCLE = constants.SHARD_STRATEGY_CYCLE;
 
     return ImgixClient;
   })();

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -58,6 +58,30 @@ describe('Imgix client:', function describeSuite() {
         })
       }, Error);
     });
+
+    it('errors with invalid domain - appended slash', function testSpec() {
+      assert.throws(function() {
+        new ImgixClient({
+          domains: ['my-host1.imgix.net/'],
+        })
+      }, Error);
+    });
+
+    it('errors with invalid domain - prepended scheme ', function testSpec() {
+      assert.throws(function() {
+        new ImgixClient({
+          domains: ['https://my-host1.imgix.net'],
+        })
+      }, Error);
+    });
+
+    it('errors with invalid domain - appended dash ', function testSpec() {
+      assert.throws(function() {
+        new ImgixClient({
+          domains: ['my-host1.imgix.net-'],
+        })
+      }, Error);
+    });
   });
 
   describe('Calling _sanitizePath()', function describeSuite() {


### PR DESCRIPTION
Adds a validation that will throw an error if a user attempts to initialize a new `ImgixClient` object with an invalid domain.
The validation criteria is based off of the same regex used on [dashboard.imgix.com](https://dashboard.imgix.com)