### PR TITLE
docs: deprecate settings.domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ console.log(url); // => "https://my-social-network.imgix.net/users/1.png?w=400&h
 ```
 
 ## Domain Sharded URLs
-**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release. As a result, the `domains` argument will be deprecated in favor of `domain` instead.**<br>
 To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
 
 Domain sharding enables you to spread image requests across multiple domains.

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -47,7 +47,7 @@
         this.settings.domains = [this.settings.domains];
       }
       else {
-        console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.");
+        console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
       }
 
       if (!this.settings.host && this.settings.domains.length === 0) {

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -37,7 +37,7 @@ describe('Imgix client:', function describeSuite() {
     });
 
     it('initializes with domains list', function testSpec() {
-      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
       stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         assert.equal(warning, deprecation_warning);
       });
@@ -55,7 +55,7 @@ describe('Imgix client:', function describeSuite() {
     });
 
     it('errors with invalid shard strategy', function testSpec() {
-      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
       var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         assert.equal(warning, deprecation_warning);
       });
@@ -71,7 +71,7 @@ describe('Imgix client:', function describeSuite() {
     });
 
     it('errors with invalid domain - appended slash', function testSpec() {
-      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
       var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         assert.equal(warning, deprecation_warning);
       });
@@ -84,7 +84,7 @@ describe('Imgix client:', function describeSuite() {
     });
 
     it('errors with invalid domain - prepended scheme ', function testSpec() {
-      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
       var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         assert.equal(warning, deprecation_warning);
       });
@@ -97,7 +97,7 @@ describe('Imgix client:', function describeSuite() {
     });
 
     it('errors with invalid domain - appended dash ', function testSpec() {
-      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+      var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
       var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         assert.equal(warning, deprecation_warning);
       });
@@ -372,7 +372,7 @@ describe('Imgix client:', function describeSuite() {
   describe('Sharding', function describeSuite() {
     describe('CRC', function describeSuite() {
       it('path resolves to same domain', function testSpec() {
-        var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+        var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
         var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
           assert.equal(warning, deprecation_warning);
         });
@@ -412,7 +412,7 @@ describe('Imgix client:', function describeSuite() {
 
     describe('Cyclic', function describeSuite() {
       it('domains cycle', function testSpec() {
-        var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+        var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
         var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
           assert.equal(warning, deprecation_warning);
         });
@@ -434,7 +434,7 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('single domain sharding', function testSpec() {
-        var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.";
+        var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
         var stub = sinon.stub(console, 'warn').callsFake(function(warning) {
           assert.equal(warning, deprecation_warning);
         });


### PR DESCRIPTION
This PR adds further detail to the sharding deprecation warning, alerting users that `settings.domains` will be deprecated in favor of `settings.domain`. This change should precede the domain sharding removal release.