### PR TITLE
feat: add settings.domain argument

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -78,7 +78,7 @@
       }
 
       if (this.settings.host) {
-        console.warn("'host' argument is deprecated; use 'domains' instead.");
+        console.warn("'host' argument is deprecated; either use 'domain' or 'domains' instead.");
         if (this.settings.domains.length == 0)
           this.settings.domains[0] = this.settings.host;
       }

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -44,33 +44,27 @@
         this.settings[key] = val;
       }
 
-      // If settings.domains is passed in as an array of 1 or more elements
-      // will generate a deprecation warning
-      if (Array.isArray(this.settings.domains) && this.settings.domains.length > 0) {
-        console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
-      }
-      // If settings.domains is passed in as a signle domain str
-      // will keep original behavior
-      else if (!Array.isArray(this.settings.domains)) {
-        this.settings.domains = [this.settings.domains];
-      }
-      // If new domain argument is being used
-      else {
-        // If domain is passed an array
-        // check if it is an array > 1 elements
-        if (Array.isArray(this.settings.domain)) {
-          if(this.settings.domain.length > 1) {
-            throw new Error('ImgixClient.settings.domain cannot take multiple domains');
+      if (Array.isArray(this.settings.domains)) { 
+        if (this.settings.domains.length > 1) {
+          console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
+        }
+        else if (this.settings.domains.length != 1)
+        {
+          if (Array.isArray(this.settings.domain)) {
+            if(this.settings.domain.length > 1) {
+              throw new Error('ImgixClient.settings.domain cannot take multiple domains');
+            }
+            else {
+              this.settings.domains = this.settings.domain;
+            }
           }
           else {
-            this.settings.domains = this.settings.domain;
+            this.settings.domains = [this.settings.domain];
           }
         }
-        // If domain is passed in as a string
-        // this keeps behavior consistent 
-        else {
-          this.settings.domains = [this.settings.domain];
-        }
+      }
+      else if (!Array.isArray(this.settings.domains)) {
+        this.settings.domains = [this.settings.domains];
       }
       
       if (!this.settings.host && this.settings.domains == 0) {

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -48,22 +48,17 @@
         if (this.settings.domains.length > 1) {
           console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
         }
-        else if (this.settings.domains.length != 1)
+        else if (this.settings.domains.length == 0)
         {
-          if (Array.isArray(this.settings.domain)) {
-            if(this.settings.domain.length > 1) {
-              throw new Error('ImgixClient.settings.domain cannot take multiple domains');
-            }
-            else {
-              this.settings.domains = this.settings.domain;
-            }
+          if (typeof(this.settings.domain) != "string" && this.settings.domain != null) {
+              throw new Error('ImgixClient.settings.domain only accepts a string argument');
           }
           else {
             this.settings.domains = [this.settings.domain];
           }
         }
       }
-      else if (!Array.isArray(this.settings.domains)) {
+      else {
         this.settings.domains = [this.settings.domains];
       }
       

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -48,10 +48,9 @@
         if (this.settings.domains.length > 1) {
           console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
         }
-        else if (this.settings.domains.length == 0)
-        {
+        else if (this.settings.domains.length == 0) {
           if (typeof(this.settings.domain) != "string" && this.settings.domain != null) {
-              throw new Error('ImgixClient.settings.domain only accepts a string argument');
+            throw new Error('ImgixClient.settings.domain only accepts a string argument');
           }
           else {
             this.settings.domains = [this.settings.domain];
@@ -61,9 +60,9 @@
       else {
         this.settings.domains = [this.settings.domains];
       }
-      
+
       if (!this.settings.host && this.settings.domains == 0) {
-          throw new Error('ImgixClient must be passed valid domain(s)');
+        throw new Error('ImgixClient must be passed valid domain(s)');
       }
 
       if (this.settings.shard_strategy !== SHARD_STRATEGY_CRC

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -20,6 +20,7 @@
   var DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i;
   var DEFAULTS = {
     host: null,
+    domain: null,
     domains: [],
     useHTTPS: true,
     includeLibraryParam: true,
@@ -43,15 +44,37 @@
         this.settings[key] = val;
       }
 
-      if (!Array.isArray(this.settings.domains)) {
-        this.settings.domains = [this.settings.domains];
-      }
-      else {
+      // If settings.domains is passed in as an array of 1 or more elements
+      // will generate a deprecation warning
+      if (Array.isArray(this.settings.domains) && this.settings.domains.length > 0) {
         console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
       }
-
-      if (!this.settings.host && this.settings.domains.length === 0) {
-        throw new Error('ImgixClient must be passed valid domain(s)');
+      // If settings.domains is passed in as a signle domain str
+      // will keep original behavior
+      else if (!Array.isArray(this.settings.domains)) {
+        this.settings.domains = [this.settings.domains];
+      }
+      // If new domain argument is being used
+      else {
+        // If domain is passed an array
+        // check if it is an array > 1 elements
+        if (Array.isArray(this.settings.domain)) {
+          if(this.settings.domain.length > 1) {
+            throw new Error('ImgixClient.settings.domain cannot take multiple domains');
+          }
+          else {
+            this.settings.domains = this.settings.domain;
+          }
+        }
+        // If domain is passed in as a string
+        // this keeps behavior consistent 
+        else {
+          this.settings.domains = [this.settings.domain];
+        }
+      }
+      
+      if (!this.settings.host && this.settings.domains == 0) {
+          throw new Error('ImgixClient must be passed valid domain(s)');
       }
 
       if (this.settings.shard_strategy !== SHARD_STRATEGY_CRC

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -108,6 +108,33 @@ describe('Imgix client:', function describeSuite() {
       }, Error);
       stub.restore();
     });
+
+    it('accepts argument "domain" as a single domain name', function testSpec() {
+      var expectedUrl = 'https://my-host.imgix.net/image.jpg?ixlib=js-'+ImgixClient.VERSION;
+      var client = new ImgixClient({ domain: 'my-host.imgix.net' });
+      assert.equal("my-host.imgix.net", client.settings.domain);
+      assert.equal(expectedUrl, client.buildURL('image.jpg'));
+    });
+
+    it('accepts both arguments "domains" and "domain", giving priority to "domains"', function testSpec() {
+      var expectedUrl = 'https://my-host.imgix.net/image.jpg?ixlib=js-'+ImgixClient.VERSION;
+      var client = new ImgixClient({ domains: 'my-host.imgix.net', domain: 'other-domain.imgix.net' });
+      assert.equal("my-host.imgix.net", client.settings.domains);
+      assert.equal(expectedUrl, client.buildURL('image.jpg'));
+    });
+
+    it('errors when "domain" is passed multiple domains', function testSpec() {
+      assert.throws(function() {
+        new ImgixClient({ domain: ['my-host.imgix.net', 'another-domain.imgix.net'] });
+      }, Error);
+    });
+
+    it('errors when neither "domains" nor "domain" is passed', function testSpec() {
+      assert.throws(function() {
+        new ImgixClient({});
+      }, Error);
+    });
+
   });
 
   describe('Calling _sanitizePath()', function describeSuite() {


### PR DESCRIPTION
This PR is a follow up to #43, creating a new field in the `ImgixClient` object that will replace `settings.domains` once domain sharding is removed.