### PR TITLE
fix: allow `ImgixClient` to be initialized by using the deprecated `host` argument

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -49,32 +49,31 @@
           console.warn("Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.");
         }
         else if (this.settings.domains.length == 0) {
-          if (typeof(this.settings.domain) != "string" && this.settings.domain != null) {
-            throw new Error('ImgixClient.settings.domain only accepts a string argument');
+          if (this.settings.host) {
+            console.warn("'host' argument is deprecated; either use 'domain' or 'domains' instead.");
+            this.settings.domains[0] = this.settings.host;
+          }
+          else if(this.settings.domain != null) {
+            if (typeof this.settings.domain == "string") {
+              this.settings.domains = [this.settings.domain];
+            }
+            else {
+              throw new Error('ImgixClient.settings.domain only accepts a string argument');
+            }
           }
           else {
-            this.settings.domains = [this.settings.domain];
+            throw new Error('ImgixClient must be passed valid domain(s)');
           }
         }
       }
-      else {
+      else if (this.settings.domains.length != 0) {
         this.settings.domains = [this.settings.domains];
-      }
-
-      if (!this.settings.host && this.settings.domains == 0) {
-        throw new Error('ImgixClient must be passed valid domain(s)');
       }
 
       if (this.settings.shard_strategy !== SHARD_STRATEGY_CRC
           && this.settings.shard_strategy !== SHARD_STRATEGY_CYCLE) {
         throw new Error('Shard strategy must be one of ' +
           SHARD_STRATEGY_CRC + ' or ' + SHARD_STRATEGY_CYCLE);
-      }
-
-      if (this.settings.host) {
-        console.warn("'host' argument is deprecated; either use 'domain' or 'domains' instead.");
-        if (this.settings.domains.length == 0)
-          this.settings.domains[0] = this.settings.host;
       }
 
       this.settings.domains.forEach(function(domain) {

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -54,6 +54,21 @@ describe('Imgix client:', function describeSuite() {
       stub.restore();
     });
 
+    it('initializes with host', function testSpec() {
+      var deprecation_warning = "'host' argument is deprecated; either use 'domain' or 'domains' instead.";
+      stub = sinon.stub(console, 'warn').callsFake(function(warning) {
+        var client = new ImgixClient({
+          host: 'my-host.imgix.net',
+          useHTTPS: false
+        });
+        assert.equal(warning, deprecation_warning);
+        assert.equal(client.settings.domains.length, 1);
+        assert.equal("my-host.imgix.net", client.settings.domains[0]);
+        assert.equal(false, client.settings.useHTTPS);
+      });
+      stub.restore();
+    });
+    
     it('errors with invalid shard strategy', function testSpec() {
       var deprecation_warning = "Warning: Domain sharding has been deprecated and will be removed in the next major version.\nAs a result, the 'domains' argument will be deprecated in favor of 'domain' instead.";
       var stub = sinon.stub(console, 'warn').callsFake(function(warning) {


### PR DESCRIPTION
This PR addresses a bug in which `ImgixClient` did not respect the `host` argument during initialization