### PR TITLE
feat: add srcset generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,49 @@ var url = client.buildURL('/path/to/image.png', { w: 400, h: 300 });
 console.log(url); // => "https://my-social-network.imgix.net/users/1.png?w=400&h=300"
 ```
 
+## Srcset Generation
+
+The imgix-core-js module allows for generation of custom `srcset` attributes, which can be invoked through `buildSrcSet()`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.
+
+```js
+var client = new ImgixClient({domain:'my-social-network.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
+var srcset = client.buildSrcSet('image.jpg');
+
+console.log(srcset);
+```
+
+Will produce the following attribute value, which can then be served to the client:
+
+```html
+https://my-social-network.imgix.net/image.jpg?w=100&s=e2e581a39c917bdee50b2f8689c30893 100w,
+https://my-social-network.imgix.net/image.jpg?w=116&s=836e0bc15da2ad74af8130d93a0ebda6 116w,
+https://my-social-network.imgix.net/image.jpg?w=134&s=688416d933381acda1f57068709aab79 134w,
+                                            ...
+https://my-social-network.imgix.net/image.jpg?w=7400&s=91779d82a0e1ac16db04c522fa4017e5 7400w,
+https://my-social-network.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 8192w
+```
+
+In cases where enough information is provided about an image's dimensions, `buildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `buildSrcSet()` with either a width **or** the height and aspect ratio provided, a different `srcset` will be generated for a fixed-size image instead.
+
+```rb
+var client = new ImgixClient({domain:'my-social-network.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
+var srcset = client.buildSrcSet('image.jpg', {h:800, ar:'3:2'});
+
+console.log(srcset);
+```
+
+Will produce the following attribute value:
+
+```html
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 1x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 2x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 3x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 4x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 5x
+```
+
+For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
 ## What is the `ixlib` param on every request?
 
 For security and diagnostic purposes, we sign all requests with the language and version of library used to generate the URL.

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -71,44 +71,28 @@
     };
 
     ImgixClient.prototype.buildSrcSet = function (path, params) {
-      var width = params['w'];
-      var height = params['h'];
-      var aspectRatio = params['ar'];
-      var aspectRatioAsDecimal = function() {
-        if (typeof aspectRatio !== "string") {
-          return false;
-        }
-        var isValidFormat = function(str) {
-          return /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(str);
-        };
-        if (!isValidFormat(aspectRatio)) {
-          return false;
-        }
       
-        const aspectRatioSplit = aspectRatio.split(":");
-        var arWidth = aspectRatioSplit[0];
-        var arHeight = aspectRatioSplit[1];
-      
-        return parseFloat(arWidth) / parseFloat(arHeight);
+      var width = params ? params['w'] : undefined;
+      var height = params ? params['h'] : undefined;
+      var aspectRatio = params ? params['ar'] : undefined;
+
+      // determines if an aspect ratio value is in the correct format 'w:h'
+      var isValidFormat = function() {
+        return /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(aspectRatio);
       }();
+
+      if (aspectRatio && !isValidFormat) {
+        throw new Error('The \'ar\' parameter key must follow the format w:h');
+      }
 
       var fixedWidth = ((width && height) || (width && aspectRatio) || (height && aspectRatio)) ? true : false;
 
       if (fixedWidth) {
-        if (width && height) {
-          return this._buildDPRSrcSet(path, params);
-        }
-        else if (aspectRatio) { 
-          if (width) {
-            params['h'] = width / aspectRatioAsDecimal;
-          }
-          else if (height) {
-            params['w'] = height * aspectRatioAsDecimal;
-          }
-          return this._buildDPRSrcSet(path, params);
-        }
+        return this._buildDPRSrcSet(path, params);
       }
-      return this._buildSrcSetPairs(path, params);
+      else {
+        return this._buildSrcSetPairs(path, params);
+      }
     };
 
     ImgixClient.prototype._buildSrcSetPairs = function(path, params) {

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -150,16 +150,6 @@
       var width = params ? params['w'] : undefined;
       var height = params ? params['h'] : undefined;
       var aspectRatio = params ? params['ar'] : undefined;
-      if (params) {
-        delete params.dpr;
-      }
-      
-      // determines if an aspect ratio value is in the correct format 'w:h'
-      var isValidFormat = /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(aspectRatio);
-
-      if (aspectRatio && !isValidFormat) {
-        throw new Error('The \'ar\' parameter key must follow the format w:h');
-      }
 
       if ((width) || (height && aspectRatio)) {
         return this._buildDPRSrcSet(path, params);

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -101,7 +101,8 @@
 
       for(var i = 0; i < targetWidths.length; i++) {
         currentWidth = targetWidths[i];
-        srcset += this.buildURL(path, {...params, 'w':currentWidth}) + ' ' + currentWidth + 'w,\n';
+        params['w'] = currentWidth;
+        srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
       }
 
       return srcset.slice(0,-2);

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -159,7 +159,7 @@
       }
 
       // If two of the three are defined, this is a fixed-dimension srcset
-      if (((width && height) || (width && aspectRatio) || (height && aspectRatio))) {
+      if ((width && height) || (width && aspectRatio) || (height && aspectRatio)) {
         return this._buildDPRSrcSet(path, params);
       }
       else {

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -185,7 +185,7 @@
 
     ImgixClient.prototype._buildDPRSrcSet = function(path, params) {
         var srcset = '';
-        var targetRatios = [1,2,3,4,5];
+        var targetRatios = [1, 2, 3, 4, 5];
         var url = this.buildURL(path, params);
         
         for(var i = 0; i < targetRatios.length; i++) {

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -70,6 +70,18 @@
       return this.settings.urlPrefix + this.settings.domain + path + queryParams;
     };
 
+    ImgixClient.prototype.buildSrcSet = function (path, params) {
+      var srcset = '';
+      var targetWidths = this._targetWidths();
+
+      for(var i = 0; i < targetWidths.length; i++) {
+        currentWidth = targetWidths[i];
+        srcset += this.buildURL(path, {...params, 'w':currentWidth}) + ' ' + currentWidth + 'w,\n';
+      }
+
+      return srcset;
+    };
+
     ImgixClient.prototype._sanitizePath = function(path) {
       // Strip leading slash first (we'll re-add after encoding)
       path = path.replace(/^\//, '');
@@ -122,6 +134,23 @@
       } else {
         return queryParams = "?s=" + signature;
       }
+    };
+
+    ImgixClient.prototype._targetWidths = function() {
+      var resolutions = [];
+      var prev = 100;
+      var INCREMENT_PERCENTAGE = 8;
+      var MAX_SIZE = 8192;
+    
+      var ensureEven = n => 2 * Math.round(n / 2);
+    
+      while (prev <= MAX_SIZE) {
+        resolutions.push(ensureEven(prev));
+        prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
+      }
+    
+      resolutions.push(MAX_SIZE);
+      return resolutions;
     };
 
     ImgixClient.VERSION = VERSION;

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -150,6 +150,7 @@
       var width = params ? params['w'] : undefined;
       var height = params ? params['h'] : undefined;
       var aspectRatio = params ? params['ar'] : undefined;
+      delete params.dpr;
 
       // determines if an aspect ratio value is in the correct format 'w:h'
       var isValidFormat = /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(aspectRatio);
@@ -158,8 +159,7 @@
         throw new Error('The \'ar\' parameter key must follow the format w:h');
       }
 
-      // If two of the three are defined, this is a fixed-dimension srcset
-      if ((width && height) || (width && aspectRatio) || (height && aspectRatio)) {
+      if ((width) || (height && aspectRatio)) {
         return this._buildDPRSrcSet(path, params);
       }
       else {

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -168,11 +168,12 @@
       
         resolutions.push(MAX_SIZE);
         return resolutions;
-      };
+      }();
 
       for(var i = 0; i < targetWidths.length; i++) {
         currentWidth = targetWidths[i];
-        params['w'] = currentWidth;
+        currentParams = params ? params : {};
+        currentParams['w'] = currentWidth;
         srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
       }
 

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -150,8 +150,10 @@
       var width = params ? params['w'] : undefined;
       var height = params ? params['h'] : undefined;
       var aspectRatio = params ? params['ar'] : undefined;
-      delete params.dpr;
-
+      if (params) {
+        delete params.dpr;
+      }
+      
       // determines if an aspect ratio value is in the correct format 'w:h'
       var isValidFormat = /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(aspectRatio);
 

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -125,7 +125,6 @@
     };
 
     ImgixClient.prototype.buildSrcSet = function (path, params) {
-      
       var width = params ? params['w'] : undefined;
       var height = params ? params['h'] : undefined;
       var aspectRatio = params ? params['ar'] : undefined;
@@ -174,7 +173,7 @@
         currentWidth = targetWidths[i];
         currentParams = params ? params : {};
         currentParams['w'] = currentWidth;
-        srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
+        srcset += this.buildURL(path, currentParams) + ' ' + currentWidth + 'w,\n';
       }
 
       return srcset.slice(0,-2);

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -339,7 +339,7 @@ describe('Imgix client:', function describeSuite() {
 
   describe('Calling buildSrcSet()', function describeSuite() {
 
-    it('removes any dpr parameter provided', function testSpec(){
+    it('removes any dpr parameter provided', function testSpec() {
       var srcset = new ImgixClient({
         domain: 'testing.imgix.net',
         includeLibraryParam: false,
@@ -355,7 +355,7 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg', {w:100});
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
         assert(srcset.split(",").length == 5);
   
         var devicePixelRatios = srcset.split(",")
@@ -370,7 +370,7 @@ describe('Imgix client:', function describeSuite() {
         assert(devicePixelRatios[4] == '5x');
       });
 
-      it('should correctly sign each URL', function testSpec() {  
+      it('should correctly sign each URL', function testSpec() {
         var signKey = "s=b95cfd915f4a198442bff4ce5befe5b8";
   
         srcset.split(",")
@@ -568,7 +568,7 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg', {w:100,ar:'3:2'});
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
         assert(srcset.split(",").length == 5);
   
         var devicePixelRatios = srcset.split(",")
@@ -583,7 +583,7 @@ describe('Imgix client:', function describeSuite() {
         assert(devicePixelRatios[4] == '5x');
       });
 
-      it('should correctly sign each URL', function testSpec() {  
+      it('should correctly sign each URL', function testSpec() {
         var signKey = "s=14244344b49d2933eb9dc227af37c24a";
   
         srcset.split(",")
@@ -602,7 +602,7 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg', {h:100,ar:'3:2'});
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
         assert(srcset.split(",").length == 5);
   
         var devicePixelRatios = srcset.split(",")
@@ -617,7 +617,7 @@ describe('Imgix client:', function describeSuite() {
         assert(devicePixelRatios[4] == '5x');
       });
 
-      it('should correctly sign each URL', function testSpec() {  
+      it('should correctly sign each URL', function testSpec() {
         var signKey = "s=84db8cb226483fc0130b4fb58e1e6ff2";
   
         srcset.split(",")

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -338,16 +338,6 @@ describe('Imgix client:', function describeSuite() {
   });
 
   describe('Calling buildSrcSet()', function describeSuite() {
-
-    it('removes any dpr parameter provided', function testSpec() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {dpr:1});
-
-      assert(!srcset.includes('dpr='));
-    });
     describe('with a width parameter provided', function describeSuite() {
       var srcset = new ImgixClient({
         domain: 'testing.imgix.net',
@@ -389,6 +379,11 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg', {h:100});
 
+      it('should respect the height parameter', function testSpec(){
+        srcset.split(',').map(function (src) {
+          assert(src.includes('h='));
+        });
+      });
       it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
         assert.equal(srcset.split(',').length, 31);
       });
@@ -494,11 +489,6 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg',{ar:'3:2'});
 
-      it('should error if the ar parameter is not passed in the correct format', function testSpec() {
-        assert.throws(function() {
-          client.buildSrcSet('image.jpg', {ar:'3x2'});
-        }, Error);
-      });
       it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
         assert.equal(srcset.split(',').length, 31);
       });

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var ImgixClient = require('../src/imgix-core-js');
 var sinon = require('sinon');
+var md5 = require("md5");
 
 describe('Imgix client:', function describeSuite() {
   describe('The constructor', function describeSuite() {
@@ -337,15 +338,59 @@ describe('Imgix client:', function describeSuite() {
   });
 
   describe('Calling buildSrcSet()', function describeSuite() {
-    describe('width descriptor mode', function describeSuite() {
+
+    it('removes any dpr parameter provided', function testSpec(){
       var srcset = new ImgixClient({
         domain: 'testing.imgix.net',
         includeLibraryParam: false,
         secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg');
-      
-      it('returns the expected number of `url widthDescriptor` pairs', function testSpec() {
-        assert.equal(srcset.split(',').length,31);
+      }).buildSrcSet('image.jpg', {dpr:1});
+
+      assert(!srcset.includes('dpr='));
+    });
+    describe('with a width parameter provided', function describeSuite() {
+      var srcset = new ImgixClient({
+        domain: 'testing.imgix.net',
+        includeLibraryParam: false,
+        secureURLToken: 'MYT0KEN'
+      }).buildSrcSet('image.jpg', {w:100});
+
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+        assert(srcset.split(",").length == 5);
+  
+        var devicePixelRatios = srcset.split(",")
+        .map(function (srcsetSplit){
+          return srcsetSplit.split(" ")[1];
+        })
+        
+        assert(devicePixelRatios[0] == '1x');
+        assert(devicePixelRatios[1] == '2x');
+        assert(devicePixelRatios[2] == '3x');
+        assert(devicePixelRatios[3] == '4x');
+        assert(devicePixelRatios[4] == '5x');
+      });
+
+      it('should correctly sign each URL', function testSpec() {  
+        var signKey = "s=b95cfd915f4a198442bff4ce5befe5b8";
+  
+        srcset.split(",")
+        .map(function (srcsetSplit) {
+          return srcsetSplit.split(" ")[0];
+        }).map(function (src) {
+          assert(src.includes(signKey));
+        });
+      });
+    });
+
+    describe('with a height parameter provided', function describeSuite() {
+      var srcset = new ImgixClient({
+        domain: 'testing.imgix.net',
+        includeLibraryParam: false,
+        secureURLToken: 'MYT0KEN'
+      }).buildSrcSet('image.jpg', {h:100});
+
+      it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+        assert.equal(srcset.split(',').length, 31);
       });
       it('should not exceed the bounds of [100, 8192]', function testSpec() {
         var srcsetSplit = srcset.split(",");
@@ -375,9 +420,9 @@ describe('Imgix client:', function describeSuite() {
           })
           .map(Number.parseFloat)
         }();
-
+  
         let prev = srcsetWidths[0];
-
+  
         for (let index = 1; index < srcsetWidths.length; index++) {
           var element = srcsetWidths[index];
           assert((element / prev) < (1 + INCREMENT_ALLOWED));
@@ -385,25 +430,38 @@ describe('Imgix client:', function describeSuite() {
         }
       });
       it('should correctly sign each URL', function testSpec() {
+        var path = '/image.jpg';
+        var param, signatureBase, signature;
+  
         srcset.split(",")
         .map(function (srcsetSplit) {
+          // split the url portion of each srcset entry
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
+          // asserts that the expected 's=' parameter is being generated per entry
           assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.length);
+          param = param.slice(0, param.indexOf('s=')-1);
+          signatureBase = 'MYT0KEN' + path + param;
+          signature = md5(signatureBase);
+          
+          assert.equal(src.slice(src.indexOf('s=')+2, src.length), signature);
         });
       });
     });
 
-    describe('DPR mode', function describeSuite() {
+    describe('with a width and height parameter provided', function describeSuite() {
       var srcset = new ImgixClient({
         domain: 'testing.imgix.net',
         includeLibraryParam: false,
         secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {w:'800',h:'300'});
+      }).buildSrcSet('image.jpg', {w:100,h:100});
 
-      it('srcSet should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
         assert(srcset.split(",").length == 5);
-
+  
         var devicePixelRatios = srcset.split(",")
         .map(function (srcsetSplit){
           return srcsetSplit.split(" ")[1];
@@ -415,12 +473,158 @@ describe('Imgix client:', function describeSuite() {
         assert(devicePixelRatios[3] == '4x');
         assert(devicePixelRatios[4] == '5x');
       });
-      it('should correctly sign each URL', function testSpec() {
+
+      it('should correctly sign each URL', function testSpec() {  
+        var signKey = "s=fb081a45c449b28f69e012d474943df3";
+  
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
+          assert(src.includes(signKey));
+        });
+      });
+    });
+
+    describe('with an aspect ratio parameter provided', function describeSuite() {
+      var srcset = new ImgixClient({
+        domain: 'testing.imgix.net',
+        includeLibraryParam: false,
+        secureURLToken: 'MYT0KEN'
+      }).buildSrcSet('image.jpg',{ar:'3:2'});
+
+      it('should error if the ar parameter is not passed in the correct format', function testSpec() {
+        assert.throws(function() {
+          client.buildSrcSet('image.jpg', {ar:'3x2'});
+        }, Error);
+      });
+      it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+        assert.equal(srcset.split(',').length, 31);
+      });
+      it('should not exceed the bounds of [100, 8192]', function testSpec() {
+        var srcsetSplit = srcset.split(",");
+        var min = Number.parseFloat(
+          srcsetSplit[0]
+          .split(" ")[1]
+          .slice(0, -1)
+        );
+        var max = Number.parseFloat(
+          srcsetSplit[srcsetSplit.length-1]
+          .split(" ")[1]
+          .slice(0, -1)
+        );
+        assert(min >= 100);
+        assert(max <= 8192);
+      });
+      it('should not increase more than 18% every iteration', function testSpec() {
+        var INCREMENT_ALLOWED = 0.18;
+        
+        var srcsetWidths = function() {
+          return srcset.split(",")
+          .map(function (srcsetSplit) {
+            return srcsetSplit.split(" ")[1];
+          })
+          .map(function (width) {
+            return width.slice(0, -1);
+          })
+          .map(Number.parseFloat)
+        }();
+  
+        let prev = srcsetWidths[0];
+  
+        for (let index = 1; index < srcsetWidths.length; index++) {
+          var element = srcsetWidths[index];
+          assert((element / prev) < (1 + INCREMENT_ALLOWED));
+          prev = element;
+        }
+      });
+      it('should correctly sign each URL', function testSpec() {
+        var path = '/image.jpg';
+        var param, signatureBase, signature;
+  
+        srcset.split(",")
+        .map(function (srcsetSplit) {
+          // split the url portion of each srcset entry
+          return srcsetSplit.split(" ")[0];
+        }).map(function (src) {
+          // asserts that the expected 's=' parameter is being generated per entry
           assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.length);
+          param = param.slice(0, param.indexOf('s=')-1);
+          signatureBase = 'MYT0KEN' + path + param;
+          signature = md5(signatureBase);
+          
+          assert.equal(src.slice(src.indexOf('s=')+2, src.length), signature);
+        });
+      });
+    });
+
+    describe('with a width and aspect ratio parameter provided', function describeSuite() {
+      var srcset = new ImgixClient({
+        domain: 'testing.imgix.net',
+        includeLibraryParam: false,
+        secureURLToken: 'MYT0KEN'
+      }).buildSrcSet('image.jpg', {w:100,ar:'3:2'});
+
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+        assert(srcset.split(",").length == 5);
+  
+        var devicePixelRatios = srcset.split(",")
+        .map(function (srcsetSplit){
+          return srcsetSplit.split(" ")[1];
+        })
+        
+        assert(devicePixelRatios[0] == '1x');
+        assert(devicePixelRatios[1] == '2x');
+        assert(devicePixelRatios[2] == '3x');
+        assert(devicePixelRatios[3] == '4x');
+        assert(devicePixelRatios[4] == '5x');
+      });
+
+      it('should correctly sign each URL', function testSpec() {  
+        var signKey = "s=14244344b49d2933eb9dc227af37c24a";
+  
+        srcset.split(",")
+        .map(function (srcsetSplit) {
+          return srcsetSplit.split(" ")[0];
+        }).map(function (src) {
+          assert(src.includes(signKey));
+        });
+      });
+    });
+
+    describe('with a height and aspect ratio parameter provided', function describeSuite() {
+      var srcset = new ImgixClient({
+        domain: 'testing.imgix.net',
+        includeLibraryParam: false,
+        secureURLToken: 'MYT0KEN'
+      }).buildSrcSet('image.jpg', {h:100,ar:'3:2'});
+
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+        assert(srcset.split(",").length == 5);
+  
+        var devicePixelRatios = srcset.split(",")
+        .map(function (srcsetSplit){
+          return srcsetSplit.split(" ")[1];
+        })
+        
+        assert(devicePixelRatios[0] == '1x');
+        assert(devicePixelRatios[1] == '2x');
+        assert(devicePixelRatios[2] == '3x');
+        assert(devicePixelRatios[3] == '4x');
+        assert(devicePixelRatios[4] == '5x');
+      });
+
+      it('should correctly sign each URL', function testSpec() {  
+        var signKey = "s=84db8cb226483fc0130b4fb58e1e6ff2";
+  
+        srcset.split(",")
+        .map(function (srcsetSplit) {
+          return srcsetSplit.split(" ")[0];
+        }).map(function (src) {
+          assert(src.includes(signKey));
         });
       });
     });

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -371,13 +371,13 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {
-        var signKey = "s=b95cfd915f4a198442bff4ce5befe5b8";
+        var expected_signature = "s=b95cfd915f4a198442bff4ce5befe5b8";
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(signKey));
+          assert(src.includes(expected_signature));
         });
       });
     });
@@ -444,10 +444,11 @@ describe('Imgix client:', function describeSuite() {
           // param will have all params except for '&s=...'
           param = src.slice(src.indexOf('?'), src.length);
           param = param.slice(0, param.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
           signatureBase = 'MYT0KEN' + path + param;
-          signature = md5(signatureBase);
+          expected_signature = md5(signatureBase);
           
-          assert.equal(src.slice(src.indexOf('s=')+2, src.length), signature);
+          assert.equal(expected_signature, generated_signature);
         });
       });
     });
@@ -475,13 +476,13 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {  
-        var signKey = "s=fb081a45c449b28f69e012d474943df3";
+        var expected_signature = "s=fb081a45c449b28f69e012d474943df3";
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(signKey));
+          assert(src.includes(expected_signature));
         });
       });
     });
@@ -553,10 +554,11 @@ describe('Imgix client:', function describeSuite() {
           // param will have all params except for '&s=...'
           param = src.slice(src.indexOf('?'), src.length);
           param = param.slice(0, param.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
           signatureBase = 'MYT0KEN' + path + param;
-          signature = md5(signatureBase);
+          expected_signature = md5(signatureBase);
           
-          assert.equal(src.slice(src.indexOf('s=')+2, src.length), signature);
+          assert.equal(expected_signature, generated_signature);
         });
       });
     });
@@ -584,13 +586,13 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {
-        var signKey = "s=14244344b49d2933eb9dc227af37c24a";
+        var expected_signature = "s=14244344b49d2933eb9dc227af37c24a";
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(signKey));
+          assert(src.includes(expected_signature));
         });
       });
     });
@@ -618,13 +620,13 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {
-        var signKey = "s=84db8cb226483fc0130b4fb58e1e6ff2";
+        var expected_signature = "s=84db8cb226483fc0130b4fb58e1e6ff2";
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(signKey));
+          assert(src.includes(expected_signature));
         });
       });
     });


### PR DESCRIPTION
This PR adds a new function to the imgix-core-js interface that will either generate a width descriptor or DPR `srcset` based on the specified parameters.
Special attention should be given to cover all aspect ratio-related cases, especially with the newly available `ar` parameter.