### PR TITLE
fix: include dpr parameter when generating fixed-width srcset

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ https://my-social-network.imgix.net/image.jpg?w=7400&s=91779d82a0e1ac16db04c522f
 https://my-social-network.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 8192w
 ```
 
-In cases where enough information is provided about an image's dimensions, `buildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `buildSrcSet()` with either a width **or** the height and aspect ratio provided, a different `srcset` will be generated for a fixed-size image instead.
+In cases where enough information is provided about an image's dimensions, `buildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `buildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
-```rb
+```js
 var client = new ImgixClient({domain:'my-social-network.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
-var srcset = client.buildSrcSet('image.jpg', {h:800, ar:'3:2'});
+var srcset = client.buildSrcSet('image.jpg', {h:800, ar:'3:2',fit:'crop'});
 
 console.log(srcset);
 ```
@@ -104,11 +104,11 @@ console.log(srcset);
 Will produce the following attribute value:
 
 ```html
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 1x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 2x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 3x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 4x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&s=1aa5fff0c7cdbd749f3ce3f553d239c4 5x
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=1&s=3d754a157458402fd3e26977107ade74 1x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=2&s=a984ad1a81d24d9dd7d18195d5262c82 2x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=3&s=8b93ab83d3f1ede4887e6826112d60d1 3x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=4&s=df7b67aa0439588edbfc1c249b3965d6 4x,
+https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=5&s=7c4b8adb733db37d00240da4ca65d410 5x
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -176,10 +176,12 @@
     ImgixClient.prototype._buildDPRSrcSet = function(path, params) {
         var srcset = '';
         var targetRatios = [1, 2, 3, 4, 5];
-        
+        var currentRatio;
+
         for(var i = 0; i < targetRatios.length; i++) {
-          params.dpr = i + 1;
-          srcset += this.buildURL(path, params) + ' ' + targetRatios[i] + 'x,\n'
+          currentRatio = targetRatios[i];
+          params.dpr = currentRatio;
+          srcset += this.buildURL(path, params) + ' ' + currentRatio + 'x,\n'
         }
 
         return srcset.slice(0,-2);

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -147,9 +147,10 @@
     };
 
     ImgixClient.prototype.buildSrcSet = function (path, params) {
-      var width = params ? params['w'] : undefined;
-      var height = params ? params['h'] : undefined;
-      var aspectRatio = params ? params['ar'] : undefined;
+      var params = params || {};
+      var width = params.w;
+      var height = params.h;
+      var aspectRatio = params.ar;
 
       if ((width) || (height && aspectRatio)) {
         return this._buildDPRSrcSet(path, params);
@@ -161,13 +162,12 @@
 
     ImgixClient.prototype._buildSrcSetPairs = function(path, params) {
       var srcset = '';
-      var currentWidth, currentParams;
+      var currentWidth;
 
       for(var i = 0; i < TARGET_WIDTHS.length; i++) {
         currentWidth = TARGET_WIDTHS[i];
-        currentParams = params ? params : {};
-        currentParams['w'] = currentWidth;
-        srcset += this.buildURL(path, currentParams) + ' ' + currentWidth + 'w,\n';
+        params.w = currentWidth;
+        srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
       }
 
       return srcset.slice(0,-2);
@@ -178,10 +178,8 @@
         var targetRatios = [1, 2, 3, 4, 5];
         
         for(var i = 0; i < targetRatios.length; i++) {
-          currentRatio = targetRatios[i];
-          currentParams = params;
-          currentParams['dpr'] = i+1;
-          srcset += this.buildURL(path, currentParams) + ' ' + currentRatio +'x,\n'
+          params.dpr = i + 1;
+          srcset += this.buildURL(path, params) + ' ' + targetRatios[i] + 'x,\n'
         }
 
         return srcset.slice(0,-2);

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -176,11 +176,12 @@
     ImgixClient.prototype._buildDPRSrcSet = function(path, params) {
         var srcset = '';
         var targetRatios = [1, 2, 3, 4, 5];
-        var url = this.buildURL(path, params);
         
         for(var i = 0; i < targetRatios.length; i++) {
           currentRatio = targetRatios[i];
-          srcset += url + ' ' + currentRatio +'x,\n'
+          currentParams = params;
+          currentParams['dpr'] = i+1;
+          srcset += this.buildURL(path, currentParams) + ' ' + currentRatio +'x,\n'
         }
 
         return srcset.slice(0,-2);

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -380,8 +380,8 @@ describe('Imgix client:', function describeSuite() {
         assert(max <= 8192);
       });
 
-      it('should not increase more than 18% every iteration', function testSpec() {
-        var INCREMENT_ALLOWED = 0.18;
+      it('should not increase more than 17% every iteration', function testSpec() {
+        var INCREMENT_ALLOWED = 0.17;
         
         var srcsetWidths = function() {
           return srcset.split(",")
@@ -529,8 +529,8 @@ describe('Imgix client:', function describeSuite() {
         assert(max <= 8192);
       });
 
-      it('should not increase more than 18% every iteration', function testSpec() {
-        var INCREMENT_ALLOWED = 0.18;
+      it('should not increase more than 17% every iteration', function testSpec() {
+        var INCREMENT_ALLOWED = 0.17;
         
         var srcsetWidths = function() {
           return srcset.split(",")
@@ -672,8 +672,8 @@ describe('Imgix client:', function describeSuite() {
         assert(max <= 8192);
       });
 
-      it('should not increase more than 18% every iteration', function testSpec() {
-        var INCREMENT_ALLOWED = 0.18;
+      it('should not increase more than 17% every iteration', function testSpec() {
+        var INCREMENT_ALLOWED = 0.17;
         
         var srcsetWidths = function() {
           return srcset.split(",")

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -380,6 +380,7 @@ describe('Imgix client:', function describeSuite() {
         assert(max <= 8192);
       });
 
+      // a 17% testing threshold is used to account for rounding
       it('should not increase more than 17% every iteration', function testSpec() {
         var INCREMENT_ALLOWED = 0.17;
         
@@ -529,6 +530,7 @@ describe('Imgix client:', function describeSuite() {
         assert(max <= 8192);
       });
 
+      // a 17% testing threshold is used to account for rounding
       it('should not increase more than 17% every iteration', function testSpec() {
         var INCREMENT_ALLOWED = 0.17;
         
@@ -672,6 +674,7 @@ describe('Imgix client:', function describeSuite() {
         assert(max <= 8192);
       });
 
+      // a 17% testing threshold is used to account for rounding
       it('should not increase more than 17% every iteration', function testSpec() {
         var INCREMENT_ALLOWED = 0.17;
         

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -338,6 +338,95 @@ describe('Imgix client:', function describeSuite() {
   });
 
   describe('Calling buildSrcSet()', function describeSuite() {
+    describe('with no parameters', function describeSuite() {
+      var srcset = new ImgixClient({
+        domain: 'testing.imgix.net',
+        includeLibraryParam: false,
+        secureURLToken: 'MYT0KEN'
+      }).buildSrcSet('image.jpg');
+      
+      it('should generate the expected default srcset pair values', function testSpec(){
+        resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                       328, 380, 442, 512, 594, 688, 798, 926,
+                       1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                       3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+        srclist = srcset.split(",");
+        src = srclist.map(function (srcline){
+          return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+        })
+
+        for (var i = 0; i < srclist.length; i++) {
+          assert.equal(src[i], resolutions[i]);
+        }
+      });
+
+      it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+        assert.equal(srcset.split(',').length, 31);
+      });
+
+      it('should not exceed the bounds of [100, 8192]', function testSpec() {
+        var srcsetSplit = srcset.split(",");
+        var min = Number.parseFloat(
+          srcsetSplit[0]
+          .split(" ")[1]
+          .slice(0, -1)
+        );
+        var max = Number.parseFloat(
+          srcsetSplit[srcsetSplit.length-1]
+          .split(" ")[1]
+          .slice(0, -1)
+        );
+        assert(min >= 100);
+        assert(max <= 8192);
+      });
+
+      it('should not increase more than 18% every iteration', function testSpec() {
+        var INCREMENT_ALLOWED = 0.18;
+        
+        var srcsetWidths = function() {
+          return srcset.split(",")
+          .map(function (srcsetSplit) {
+            return srcsetSplit.split(" ")[1];
+          })
+          .map(function (width) {
+            return width.slice(0, -1);
+          })
+          .map(Number.parseFloat)
+        }();
+  
+        let prev = srcsetWidths[0];
+  
+        for (let index = 1; index < srcsetWidths.length; index++) {
+          var element = srcsetWidths[index];
+          assert((element / prev) < (1 + INCREMENT_ALLOWED));
+          prev = element;
+        }
+      });
+
+      it('should correctly sign each URL', function testSpec() {
+        var path = '/image.jpg';
+        var param, signatureBase, expected_signature;
+  
+        srcset.split(",")
+        .map(function (srcsetSplit) {
+          // split the url portion of each srcset entry
+          return srcsetSplit.split(" ")[0];
+        }).map(function (src) {
+          // asserts that the expected 's=' parameter is being generated per entry
+          assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.length);
+          param = param.slice(0, param.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+          signatureBase = 'MYT0KEN' + path + param;
+          expected_signature = md5(signatureBase);
+          
+          assert.equal(expected_signature, generated_signature);
+        });
+      });
+    });
+
     describe('with a width parameter provided', function describeSuite() {
       var srcset = new ImgixClient({
         domain: 'testing.imgix.net',
@@ -399,14 +488,31 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg', {h:100});
 
+      it('should generate the expected default srcset pair values', function testSpec(){
+        resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                       328, 380, 442, 512, 594, 688, 798, 926,
+                       1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                       3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+        srclist = srcset.split(",");
+        src = srclist.map(function (srcline){
+          return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+        })
+
+        for (var i = 0; i < srclist.length; i++) {
+          assert.equal(src[i], resolutions[i]);
+        }
+      });
+
       it('should respect the height parameter', function testSpec(){
         srcset.split(',').map(function (src) {
           assert(src.includes('h='));
         });
       });
+
       it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
         assert.equal(srcset.split(',').length, 31);
       });
+
       it('should not exceed the bounds of [100, 8192]', function testSpec() {
         var srcsetSplit = srcset.split(",");
         var min = Number.parseFloat(
@@ -422,6 +528,7 @@ describe('Imgix client:', function describeSuite() {
         assert(min >= 100);
         assert(max <= 8192);
       });
+
       it('should not increase more than 18% every iteration', function testSpec() {
         var INCREMENT_ALLOWED = 0.18;
         
@@ -444,6 +551,7 @@ describe('Imgix client:', function describeSuite() {
           prev = element;
         }
       });
+
       it('should correctly sign each URL', function testSpec() {
         var path = '/image.jpg';
         var param, signatureBase, expected_signature;
@@ -532,6 +640,22 @@ describe('Imgix client:', function describeSuite() {
       it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
         assert.equal(srcset.split(',').length, 31);
       });
+
+      it('should generate the expected default srcset pair values', function testSpec(){
+        resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                       328, 380, 442, 512, 594, 688, 798, 926,
+                       1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                       3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+        srclist = srcset.split(",");
+        src = srclist.map(function (srcline){
+          return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+        })
+
+        for (var i = 0; i < srclist.length; i++) {
+          assert.equal(src[i], resolutions[i]);
+        }
+      });
+
       it('should not exceed the bounds of [100, 8192]', function testSpec() {
         var srcsetSplit = srcset.split(",");
         var min = Number.parseFloat(
@@ -547,6 +671,7 @@ describe('Imgix client:', function describeSuite() {
         assert(min >= 100);
         assert(max <= 8192);
       });
+
       it('should not increase more than 18% every iteration', function testSpec() {
         var INCREMENT_ALLOWED = 0.18;
         
@@ -569,6 +694,7 @@ describe('Imgix client:', function describeSuite() {
           prev = element;
         }
       });
+
       it('should correctly sign each URL', function testSpec() {
         var path = '/image.jpg';
         var param, signatureBase, expected_signature;

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -361,14 +361,34 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {
-        var expected_signature = "s=b95cfd915f4a198442bff4ce5befe5b8";
-  
+        var path = '/image.jpg';
+        var param, signatureBase, expected_signature;
+
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(expected_signature));
+          // asserts that the expected 's=' parameter is being generated per entry
+          assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+          signatureBase = 'MYT0KEN' + path + param;
+          expected_signature = md5(signatureBase);
+          
+          assert.equal(expected_signature, generated_signature);
         });
+      });
+
+      it('should include a dpr param per specified src', function testSpec() {
+        
+        srclist = srcset.split(",");
+        for(var i = 0; i < srclist.length; i++)
+        {
+          src = srclist[i].split(" ")[0];
+          assert(src.includes(`dpr=${i+1}`));
+        }
       });
     });
 
@@ -426,7 +446,7 @@ describe('Imgix client:', function describeSuite() {
       });
       it('should correctly sign each URL', function testSpec() {
         var path = '/image.jpg';
-        var param, signatureBase, signature;
+        var param, signatureBase, expected_signature;
   
         srcset.split(",")
         .map(function (srcsetSplit) {
@@ -455,7 +475,7 @@ describe('Imgix client:', function describeSuite() {
         secureURLToken: 'MYT0KEN'
       }).buildSrcSet('image.jpg', {w:100,h:100});
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {        
+      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
         assert(srcset.split(",").length == 5);
   
         var devicePixelRatios = srcset.split(",")
@@ -470,15 +490,35 @@ describe('Imgix client:', function describeSuite() {
         assert(devicePixelRatios[4] == '5x');
       });
 
-      it('should correctly sign each URL', function testSpec() {  
-        var expected_signature = "s=fb081a45c449b28f69e012d474943df3";
+      it('should correctly sign each URL', function testSpec() {
+        var path = '/image.jpg';
+        var param, signatureBase, expected_signature;
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(expected_signature));
+          // asserts that the expected 's=' parameter is being generated per entry
+          assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+          signatureBase = 'MYT0KEN' + path + param;
+          expected_signature = md5(signatureBase);
+          
+          assert.equal(expected_signature, generated_signature);
         });
+      });
+
+      it('should include a dpr param per specified src', function testSpec() {
+        
+        srclist = srcset.split(",");
+        for(var i = 0; i < srclist.length; i++)
+        {
+          src = srclist[i].split(" ")[0];
+          assert(src.includes(`dpr=${i+1}`));
+        }
       });
     });
 
@@ -531,7 +571,7 @@ describe('Imgix client:', function describeSuite() {
       });
       it('should correctly sign each URL', function testSpec() {
         var path = '/image.jpg';
-        var param, signatureBase, signature;
+        var param, signatureBase, expected_signature;
   
         srcset.split(",")
         .map(function (srcsetSplit) {
@@ -576,14 +616,34 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {
-        var expected_signature = "s=14244344b49d2933eb9dc227af37c24a";
+        var path = '/image.jpg';
+        var param, signatureBase, expected_signature;
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(expected_signature));
+          // asserts that the expected 's=' parameter is being generated per entry
+          assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+          signatureBase = 'MYT0KEN' + path + param;
+          expected_signature = md5(signatureBase);
+          
+          assert.equal(expected_signature, generated_signature);
         });
+      });
+
+      it('should include a dpr param per specified src', function testSpec() {
+        
+        srclist = srcset.split(",");
+        for(var i = 0; i < srclist.length; i++)
+        {
+          src = srclist[i].split(" ")[0];
+          assert(src.includes(`dpr=${i+1}`));
+        }
       });
     });
 
@@ -610,14 +670,34 @@ describe('Imgix client:', function describeSuite() {
       });
 
       it('should correctly sign each URL', function testSpec() {
-        var expected_signature = "s=84db8cb226483fc0130b4fb58e1e6ff2";
+        var path = '/image.jpg';
+        var param, signatureBase, expected_signature;
   
         srcset.split(",")
         .map(function (srcsetSplit) {
           return srcsetSplit.split(" ")[0];
         }).map(function (src) {
-          assert(src.includes(expected_signature));
+          // asserts that the expected 's=' parameter is being generated per entry
+          assert(src.includes("s="));
+          
+          // param will have all params except for '&s=...'
+          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+          signatureBase = 'MYT0KEN' + path + param;
+          expected_signature = md5(signatureBase);
+          
+          assert.equal(expected_signature, generated_signature);
         });
+      });
+
+      it('should include a dpr param per specified src', function testSpec() {
+        
+        srclist = srcset.split(",");
+        for(var i = 0; i < srclist.length; i++)
+        {
+          src = srclist[i].split(" ")[0];
+          assert(src.includes(`dpr=${i+1}`));
+        }
       });
     });
   });


### PR DESCRIPTION
This PR adds a few things that were missed in #53, namely:
- including the `dpr` parameter when generating a DPR srcset
- mentioning the use of `fit=crop` in documentation
- more test cases for default (no parameter) calls to `buildSrcSet()`, expected srcset pair values, and DPR mode