### PR TITLE
fix: ensure URL-legal, path-illegal characters are encoded

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -103,7 +103,7 @@
       } else {
         // Use de/encodeURI if we think the path is just a path,
         // so it leaves legal characters like '/' and '@' alone
-        path = encodeURI(path);
+        path = encodeURI(path).replace(/[#?:]/g, encodeURIComponent);
       }
 
       return '/' + path;

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -141,6 +141,39 @@ describe('Imgix client:', function describeSuite() {
       });
     });
 
+    describe('with a path that contains a hash character', function describeSuite() {
+      var path = '#blessed.png';
+
+      it('properly encodes the hash character', function testSpec() {
+        var expectation = path.replace(/^#/, '%23'),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substring(1));
+      });
+    });
+
+    describe('with a path that contains a question mark', function describeSuite() {
+      var path = '?what.png';
+
+      it('properly encodes the question mark', function testSpec() {
+        var expectation = path.replace(/^\?/, '%3F'),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substring(1));
+      });
+    });
+
+    describe('with a path that contains a colon', function describeSuite() {
+      var path = ':emoji.png';
+
+      it('properly encodes the colon', function testSpec() {
+        var expectation = path.replace(/^\:/, '%3A'),
+            result = client._sanitizePath(path);
+
+        assert.equal(expectation, result.substring(1));
+      });
+    });
+
     describe('with a full HTTP URL', function describeSuite() {
       var path = 'http://example.com/images/1.png';
 

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -94,14 +94,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns the same exact path', function testSpec() {
         var expectation = path,
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
     });
 
@@ -112,14 +112,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns the same exact path', function testSpec() {
-        var expectation = path.substr(1),
+        var expectation = path.substring(1),
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
     });
 
@@ -130,14 +130,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns the same path, except with the characters encoded properly', function testSpec() {
         var expectation = encodeURI(path),
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
     });
 
@@ -181,14 +181,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
         var expectation = encodeURIComponent(path),
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
     });
 
@@ -199,14 +199,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
         var expectation = encodeURIComponent(path),
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
     });
 
@@ -217,14 +217,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
-        var expectation = encodeURIComponent(path.substr(1)),
+        var expectation = encodeURIComponent(path.substring(1)),
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
     });
 
@@ -235,14 +235,14 @@ describe('Imgix client:', function describeSuite() {
         var expectation = '/',
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(0, 1));
+        assert.equal(expectation, result.substring(0, 1));
       });
 
       it('otherwise returns a fully-encoded version of the given URL', function testSpec() {
         var expectation = encodeURIComponent(path),
             result = client._sanitizePath(path);
 
-        assert.equal(expectation, result.substr(1));
+        assert.equal(expectation, result.substring(1));
       });
 
       it('double-encodes the original encoded characters', function testSpec() {


### PR DESCRIPTION
This PR updates the path-encoding logic in `_.sanitizePath()` to ensure that three characters are properly encoded: `#`, `?`, and `:`. These characters are all URL-legal, so they're untouched by `window.encodeURI()`, but since they're used to separate parts of a valid URL they must be encoded if they're to appear in the path.