### PR TITLE
build(deps): remove typescript as runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
     "@types/node": {
       "version": "12.7.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.8.tgz",
-      "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A=="
+      "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==",
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -1558,7 +1559,8 @@
     "typescript": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,19 @@
   "types": "dist/imgix-core-js.d.ts",
   "dependencies": {
     "js-base64": "^2.1.9",
-    "md5": "^2.2.1",
-    "typescript": "^3.6.3",
-    "@types/node": "^12.7.8"
+    "md5": "^2.2.1"
   },
   "license": "BSD-2-Clause",
   "devDependencies": {
     "mocha": "6.2.2",
     "phantomjs": "2.1.7",
     "sinon": "7.5.0",
-    "uglify-js": "3.7.0"
+    "uglify-js": "3.7.0",
+    "typescript": "^3.6.3",
+    "@types/node": "^12.7.8"
+  },
+  "peerDependencies": {
+    "typescript": "^3.6.3",
+    "@types/node": "^12.7.8"
   }
 }


### PR DESCRIPTION
This PR changes the _typescript_ and _@types/node_ runtime dependencies to be `devDependencies` and `peerDependencies` instead. Typescript is not needed to run this library but is need for maintaining this project and will likely be a shared dependency on projects consuming it.
Resolves #76 