### PR TITLE
docs: restructure header and add table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 `imgix-core-js` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
 [![NPM Version](https://badge.fury.io/js/imgix-core-js.svg)](https://www.npmjs.com/package/imgix-core-js)
-[![Build Status](https://travis-ci.org/imgix/imgix-core-js.png?branch=master)](https://travis-ci.org/imgix/imgix-core-js)
+[![Build Status](https://travis-ci.org/imgix/imgix-core-js.svg?branch=master)](https://travis-ci.org/imgix/imgix-core-js)
 [![Monthly Downloads](https://img.shields.io/npm/dm/imgix-core-js.svg)](https://www.npmjs.com/package/imgix-core-js)
 [![Minified Size](https://img.shields.io/bundlephobia/min/imgix-core-js)](https://bundlephobia.com/result?p=imgix-core-js)
 [![License](https://img.shields.io/github/license/imgix/imgix-core-js)](https://github.com/imgix/imgix-core-js/blob/master/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
-# imgix-core-js
+<!-- ix-docs-ignore -->
+![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
+`imgix-core-js` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
+
+[![NPM Version](https://badge.fury.io/js/imgix-core-js.svg)](https://www.npmjs.com/package/imgix-core-js)
 [![Build Status](https://travis-ci.org/imgix/imgix-core-js.png?branch=master)](https://travis-ci.org/imgix/imgix-core-js)
+[![Monthly Downloads](https://img.shields.io/npm/dm/imgix-core-js.svg)](https://www.npmjs.com/package/imgix-core-js)
+[![Minified Size](https://img.shields.io/bundlephobia/min/imgix-core-js)](https://bundlephobia.com/result?p=imgix-core-js)
+[![License](https://img.shields.io/github/license/imgix/imgix-core-js)](https://github.com/imgix/imgix-core-js/blob/master/LICENSE.md)
 
-imgix-core-js is an npm and Bower package that provides the common boilerplate for [imgix](https://imgix.com) server and client-side JavaScript-based functionality.
+---
+<!-- /ix-docs-ignore -->
 
-imgix-core-js adheres to the [imgix-blueprint](https://github.com/imgix/imgix-blueprint) for definitions of its functionality.
-
+- [Installing](#installing)
+- [Usage](#usage)
+  - [CommonJS](#commonjs)
+  - [ES6 Modules](#es6-modules)
+  - [In-browser](#in-browser)
+- [Srcset Generation](#srcset-generation)
+- [What is the ixlib param on every request?](#what-is-the-ixlib-param-on-every-request)
+- [Testing](#testing)
 
 ## Installing
 
@@ -134,14 +148,3 @@ imgix-core-js uses mocha for testing. Here’s how to run those tests:
 ```
 npm test
 ```
-
-
-## Publishing a new version
-
-To publish a new version of the NPM package:
-
-```bash
-$ npm publish
-```
-
-The Bower package will be automatically updated when you create a new release in GitHub.


### PR DESCRIPTION
This PR restructures the header section of the README, adds more badges, and a table of contents. The header is wrapped in a tag that will exclude it from being displayed on the [imgix libraries](https://docs.imgix.com/libraries) page.

<img width="930" alt="core-js-readme" src="https://user-images.githubusercontent.com/15919091/70582137-5256e380-1b6e-11ea-8a0d-b7930623d785.png">
