### PR TITLE
feat: add support for defining a min and max srcset width

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
   - [ES6 Modules](#es6-modules)
   - [In-browser](#in-browser)
 - [Srcset Generation](#srcset-generation)
-- [What is the ixlib param on every request?](#what-is-the-ixlib-param-on-every-request)
+  - [Fixed image rendering](#fixed-image-rendering)
+  - [Minimum and Maximum Width Ranges](#minimum-and-maximum-width-ranges)
+- [What is the `ixlib` param on every request?](#what-is-the-ixlib-param-on-every-request)
 - [Testing](#testing)
 
 ## Installing
@@ -37,7 +39,7 @@ bower install --save imgix-core-js
 
 ## Usage
 
-Depending on your module system, using imgix-core-js is done a few different ways. The most common entry point will be the `Client` class. Whenever you provide data to imgix-core-js, make sure it is not already URL-encoded, as the library handles proper encoding internally.
+Depending on your module system, using imgix-core-js is done a few different ways. The most common entry point will be the `ImgixClient` class. Whenever you provide data to imgix-core-js, make sure it is not already URL-encoded, as the library handles proper encoding internally.
 
 ### CommonJS
 
@@ -105,6 +107,8 @@ https://my-social-network.imgix.net/image.jpg?w=7400&s=91779d82a0e1ac16db04c522f
 https://my-social-network.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 8192w
 ```
 
+### Fixed image rendering
+
 In cases where enough information is provided about an image's dimensions, `buildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `buildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```js
@@ -125,6 +129,40 @@ https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=5&s=7c
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
+### Minimum and Maximum Width Ranges
+
+If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing a positive integer via `minWidth` and/or `maxWidth` to the srcset-modifying parameter:
+
+```js
+var client = new ImgixClient({
+  domain:'sher.img.net',
+  includeLibraryParam: false
+  })
+var srcset = client.buildSrcSet('image.jpg', {}, {minWidth:500, maxWidth: 2000})
+
+console.log(srcset);
+```
+
+Will result in a smaller, more tailored srcset.
+
+``` html
+https://sher.img.net/image.jpg?w=500 500w,
+https://sher.img.net/image.jpg?w=580 580w,
+https://sher.img.net/image.jpg?w=672 672w,
+https://sher.img.net/image.jpg?w=780 780w,
+https://sher.img.net/image.jpg?w=906 906w,
+https://sher.img.net/image.jpg?w=1050 1050w,
+https://sher.img.net/image.jpg?w=1218 1218w,
+https://sher.img.net/image.jpg?w=1414 1414w,
+https://sher.img.net/image.jpg?w=1640 1640w,
+https://sher.img.net/image.jpg?w=1902 1902w,
+https://sher.img.net/image.jpg?w=2000 2000w
+```
+
+Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_srcset: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
+
+Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
 
 ## What is the `ixlib` param on every request?
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Depending on your module system, using imgix-core-js is done a few different way
 var ImgixClient = require('imgix-core-js');
 
 var client = new ImgixClient({
-  domain: "my-social-network.imgix.net",
+  domain: "testing.imgix.net",
   secureURLToken: "<SECURE TOKEN>"
 });
 var url = client.buildURL("/path/to/image.png", {
   w: 400,
   h: 300
 });
-console.log(url); // => "https://my-social-network.imgix.net/users/1.png?w=400&h=300&s=…"
+console.log(url); // => "https://testing.imgix.net/users/1.png?w=400&h=300&s=…"
 ```
 
 ### ES6 Modules
@@ -63,26 +63,26 @@ console.log(url); // => "https://my-social-network.imgix.net/users/1.png?w=400&h
 import ImgixClient from 'imgix-core-js'
 
 let client = new ImgixClient({
-  domain: 'my-social-network.imgix.net',
+  domain: 'testing.imgix.net',
   secureURLToken: '<SECURE TOKEN>'
 });
 
 let url = client.buildURL('/path/to/image.png', { w: 400, h: 300 });
-console.log(url); // => 'https://my-social-network.imgix.net/users/1.png?w=400&h=300&s=…'
+console.log(url); // => 'https://testing.imgix.net/users/1.png?w=400&h=300&s=…'
 ```
 
 ### In-browser
 
 ```js
 var client = new ImgixClient({
-  domain: 'my-social-network.imgix.net'
+  domain: 'testing.imgix.net'
   // Do not use signed URLs with `secureURLToken` on the client side,
   // as this would leak your token to the world. Signed URLs should
   // be generated on the server.
 });
 
 var url = client.buildURL('/path/to/image.png', { w: 400, h: 300 });
-console.log(url); // => "https://my-social-network.imgix.net/users/1.png?w=400&h=300"
+console.log(url); // => "https://testing.imgix.net/users/1.png?w=400&h=300"
 ```
 
 ## Srcset Generation
@@ -90,7 +90,7 @@ console.log(url); // => "https://my-social-network.imgix.net/users/1.png?w=400&h
 The imgix-core-js module allows for generation of custom `srcset` attributes, which can be invoked through `buildSrcSet()`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.
 
 ```js
-var client = new ImgixClient({domain:'my-social-network.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
+var client = new ImgixClient({domain:'testing.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
 var srcset = client.buildSrcSet('image.jpg');
 
 console.log(srcset);
@@ -99,12 +99,12 @@ console.log(srcset);
 Will produce the following attribute value, which can then be served to the client:
 
 ```html
-https://my-social-network.imgix.net/image.jpg?w=100&s=e2e581a39c917bdee50b2f8689c30893 100w,
-https://my-social-network.imgix.net/image.jpg?w=116&s=836e0bc15da2ad74af8130d93a0ebda6 116w,
-https://my-social-network.imgix.net/image.jpg?w=134&s=688416d933381acda1f57068709aab79 134w,
+https://testing.imgix.net/image.jpg?w=100&s=e2e581a39c917bdee50b2f8689c30893 100w,
+https://testing.imgix.net/image.jpg?w=116&s=836e0bc15da2ad74af8130d93a0ebda6 116w,
+https://testing.imgix.net/image.jpg?w=134&s=688416d933381acda1f57068709aab79 134w,
                                             ...
-https://my-social-network.imgix.net/image.jpg?w=7400&s=91779d82a0e1ac16db04c522fa4017e5 7400w,
-https://my-social-network.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 8192w
+https://testing.imgix.net/image.jpg?w=7400&s=91779d82a0e1ac16db04c522fa4017e5 7400w,
+https://testing.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 8192w
 ```
 
 ### Fixed image rendering
@@ -112,7 +112,7 @@ https://my-social-network.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e
 In cases where enough information is provided about an image's dimensions, `buildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `buildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```js
-var client = new ImgixClient({domain:'my-social-network.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
+var client = new ImgixClient({domain:'testing.imgix.net', secureURLToken:'my-token', includeLibraryParam:false});
 var srcset = client.buildSrcSet('image.jpg', {h:800, ar:'3:2',fit:'crop'});
 
 console.log(srcset);
@@ -121,22 +121,22 @@ console.log(srcset);
 Will produce the following attribute value:
 
 ```html
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=1&s=3d754a157458402fd3e26977107ade74 1x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=2&s=a984ad1a81d24d9dd7d18195d5262c82 2x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=3&s=8b93ab83d3f1ede4887e6826112d60d1 3x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=4&s=df7b67aa0439588edbfc1c249b3965d6 4x,
-https://my-social-network.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=5&s=7c4b8adb733db37d00240da4ca65d410 5x
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=1&s=3d754a157458402fd3e26977107ade74 1x,
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=2&s=a984ad1a81d24d9dd7d18195d5262c82 2x,
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=3&s=8b93ab83d3f1ede4887e6826112d60d1 3x,
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=4&s=df7b67aa0439588edbfc1c249b3965d6 4x,
+https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=5&s=7c4b8adb733db37d00240da4ca65d410 5x
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
 
 ### Minimum and Maximum Width Ranges
 
-If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing a positive integer via `minWidth` and/or `maxWidth` to the srcset-modifying parameter:
+In certain circumstances, you may want to limit the minimum or maximum value of the non-fixed `srcset` generated by the `buildSrcSet()` method. To do this, you can pass in an options object as a third argument, providing positive integers as `minWidth` and/or `maxWidth` attributes:
 
 ```js
 var client = new ImgixClient({
-  domain:'sher.img.net',
+  domain:'testing.imgix.net',
   includeLibraryParam: false
   })
 var srcset = client.buildSrcSet('image.jpg', {}, {minWidth:500, maxWidth: 2000})
@@ -147,17 +147,17 @@ console.log(srcset);
 Will result in a smaller, more tailored srcset.
 
 ``` html
-https://sher.img.net/image.jpg?w=500 500w,
-https://sher.img.net/image.jpg?w=580 580w,
-https://sher.img.net/image.jpg?w=672 672w,
-https://sher.img.net/image.jpg?w=780 780w,
-https://sher.img.net/image.jpg?w=906 906w,
-https://sher.img.net/image.jpg?w=1050 1050w,
-https://sher.img.net/image.jpg?w=1218 1218w,
-https://sher.img.net/image.jpg?w=1414 1414w,
-https://sher.img.net/image.jpg?w=1640 1640w,
-https://sher.img.net/image.jpg?w=1902 1902w,
-https://sher.img.net/image.jpg?w=2000 2000w
+https://testing.imgix.net/image.jpg?w=500 500w,
+https://testing.imgix.net/image.jpg?w=580 580w,
+https://testing.imgix.net/image.jpg?w=672 672w,
+https://testing.imgix.net/image.jpg?w=780 780w,
+https://testing.imgix.net/image.jpg?w=906 906w,
+https://testing.imgix.net/image.jpg?w=1050 1050w,
+https://testing.imgix.net/image.jpg?w=1218 1218w,
+https://testing.imgix.net/image.jpg?w=1414 1414w,
+https://testing.imgix.net/image.jpg?w=1640 1640w,
+https://testing.imgix.net/image.jpg?w=1902 1902w,
+https://testing.imgix.net/image.jpg?w=2000 2000w
 ```
 
 Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_srcset: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -17,25 +17,34 @@
   var VERSION = '2.2.1';
   // regex pattern used to determine if a domain is valid
   var DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i;
+  // minimum generated srcset width
+  var MIN_SRCSET_WIDTH = 100;
+  // maximum generated srcset width
+  var MAX_SRCSET_WIDTH = 8192;
+  // returns an array of width values used during srcset generation
+  var DEFAULT_SRCSET_WIDTHS = _generateTargetWidths(MIN_SRCSET_WIDTH, MAX_SRCSET_WIDTH);
+
   // returns an array of width values used during scrset generation
-  var TARGET_WIDTHS = (function() {
+  function _generateTargetWidths(minWidth, maxWidth) {
     var resolutions = [];
-    var prev = 100;
     var INCREMENT_PERCENTAGE = 8;
-    var MAX_SIZE = 8192;
-  
+    var minSize = minWidth;
+    var maxSize = maxWidth;
+
     var ensureEven = function(n){
       return 2 * Math.round(n / 2);
     };
-  
-    while (prev <= MAX_SIZE) {
+
+    var prev = minSize;
+    while (prev < maxSize) {
       resolutions.push(ensureEven(prev));
       prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
     }
-  
-    resolutions.push(MAX_SIZE);
+
+    resolutions.push(maxSize);
     return resolutions;
-  })();
+  };
+
   // default ImgixClient settings passed in during instantiation
   var DEFAULTS = {
     domain: null,
@@ -146,26 +155,38 @@
       }
     };
 
-    ImgixClient.prototype.buildSrcSet = function (path, params) {
+    ImgixClient.prototype.buildSrcSet = function (path, params, options) {
       var params = params || {};
       var width = params.w;
       var height = params.h;
       var aspectRatio = params.ar;
+      var options = options || {};
 
       if ((width) || (height && aspectRatio)) {
         return this._buildDPRSrcSet(path, params);
       }
       else {
-        return this._buildSrcSetPairs(path, params);
+        return this._buildSrcSetPairs(path, params, options);
       }
     };
 
-    ImgixClient.prototype._buildSrcSetPairs = function(path, params) {
+    ImgixClient.prototype._buildSrcSetPairs = function(path, params, options) {
       var srcset = '';
       var currentWidth;
+      var targetWidths;
+      var minWidth = options["minWidth"] || MIN_SRCSET_WIDTH;
+      var maxWidth = options["maxWidth"] || MAX_SRCSET_WIDTH;
 
-      for(var i = 0; i < TARGET_WIDTHS.length; i++) {
-        currentWidth = TARGET_WIDTHS[i];
+      if (minWidth != MIN_SRCSET_WIDTH || maxWidth != MAX_SRCSET_WIDTH) {
+        validateRange(minWidth, maxWidth);
+        targetWidths = _generateTargetWidths(minWidth, maxWidth);
+      }
+      else {
+        targetWidths = DEFAULT_SRCSET_WIDTHS;
+      }
+
+      for (var i = 0; i < targetWidths.length; i++) {
+        currentWidth = targetWidths[i];
         params.w = currentWidth;
         srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
       }
@@ -178,13 +199,19 @@
         var targetRatios = [1, 2, 3, 4, 5];
         var currentRatio;
 
-        for(var i = 0; i < targetRatios.length; i++) {
+        for (var i = 0; i < targetRatios.length; i++) {
           currentRatio = targetRatios[i];
           params.dpr = currentRatio;
           srcset += this.buildURL(path, params) + ' ' + currentRatio + 'x,\n'
         }
 
         return srcset.slice(0,-2);
+    };
+
+    validateRange = function(minSrcset, maxSrcset) {
+      if (!(typeof minSrcset == 'number' && typeof maxSrcset == 'number') || (minSrcset < 0 || maxSrcset < 0)) {
+          throw new Error('The min and max srcset widths must be passed positive Number values');
+      }
     };
 
     ImgixClient.VERSION = VERSION;

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -28,20 +28,20 @@
   function _generateTargetWidths(minWidth, maxWidth) {
     var resolutions = [];
     var INCREMENT_PERCENTAGE = 8;
-    var minSize = minWidth;
-    var maxSize = maxWidth;
+    var minWidth = Math.floor(minWidth);
+    var maxWidth = Math.floor(maxWidth);
 
     var ensureEven = function(n){
       return 2 * Math.round(n / 2);
     };
 
-    var prev = minSize;
-    while (prev < maxSize) {
+    var prev = minWidth;
+    while (prev < maxWidth) {
       resolutions.push(ensureEven(prev));
       prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
     }
 
-    resolutions.push(maxSize);
+    resolutions.push(maxWidth);
     return resolutions;
   };
 
@@ -208,8 +208,8 @@
         return srcset.slice(0,-2);
     };
 
-    validateRange = function(minSrcset, maxSrcset) {
-      if (!(typeof minSrcset == 'number' && typeof maxSrcset == 'number') || (minSrcset < 0 || maxSrcset < 0)) {
+    function validateRange(min, max) {
+      if (!(typeof min == 'number' && typeof max == 'number') || (min < 0 || max < 0)) {
           throw new Error('The min and max srcset widths must be passed positive Number values');
       }
     };

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -371,495 +371,580 @@ describe('Imgix client:', function describeSuite() {
   });
 
   describe('Calling buildSrcSet()', function describeSuite() {
-    describe('with no parameters', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg');
-      
-      it('should generate the expected default srcset pair values', function testSpec(){
-        resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                       328, 380, 442, 512, 594, 688, 798, 926,
-                       1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                       3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
-        srclist = srcset.split(",");
-        src = srclist.map(function (srcline){
-          return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
-        })
-
-        for (var i = 0; i < srclist.length; i++) {
-          assert.equal(src[i], resolutions[i]);
-        }
-      });
-
-      it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
-        assert.equal(srcset.split(',').length, 31);
-      });
-
-      it('should not exceed the bounds of [100, 8192]', function testSpec() {
-        var srcsetSplit = srcset.split(",");
-        var min = Number.parseFloat(
-          srcsetSplit[0]
-          .split(" ")[1]
-          .slice(0, -1)
-        );
-        var max = Number.parseFloat(
-          srcsetSplit[srcsetSplit.length-1]
-          .split(" ")[1]
-          .slice(0, -1)
-        );
-        assert(min >= 100);
-        assert(max <= 8192);
-      });
-
-      // a 17% testing threshold is used to account for rounding
-      it('should not increase more than 17% every iteration', function testSpec() {
-        var INCREMENT_ALLOWED = 0.17;
+    describe('using image parameters', function describeSuite(){
+      describe('with no parameters', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg');
         
-        var srcsetWidths = function() {
-          return srcset.split(",")
+        it('should generate the expected default srcset pair values', function testSpec(){
+          resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                         328, 380, 442, 512, 594, 688, 798, 926,
+                         1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                         3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+          srclist = srcset.split(",");
+          src = srclist.map(function (srcline){
+            return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+          })
+
+          for (var i = 0; i < srclist.length; i++) {
+            assert.equal(src[i], resolutions[i]);
+          }
+        });
+
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.equal(srcset.split(',').length, 31);
+        });
+
+        it('should not exceed the bounds of [100, 8192]', function testSpec() {
+          var srcsetSplit = srcset.split(",");
+          var min = Number.parseFloat(
+            srcsetSplit[0]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          var max = Number.parseFloat(
+            srcsetSplit[srcsetSplit.length-1]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          assert(min >= 100);
+          assert(max <= 8192);
+        });
+
+        // a 17% testing threshold is used to account for rounding
+        it('should not increase more than 17% every iteration', function testSpec() {
+          var INCREMENT_ALLOWED = 0.17;
+          
+          var srcsetWidths = function() {
+            return srcset.split(",")
+            .map(function (srcsetSplit) {
+              return srcsetSplit.split(" ")[1];
+            })
+            .map(function (width) {
+              return width.slice(0, -1);
+            })
+            .map(Number.parseFloat)
+          }();
+
+          let prev = srcsetWidths[0];
+
+          for (let index = 1; index < srcsetWidths.length; index++) {
+            var element = srcsetWidths[index];
+            assert((element / prev) < (1 + INCREMENT_ALLOWED));
+            prev = element;
+          }
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
+
+          srcset.split(",")
           .map(function (srcsetSplit) {
+            // split the url portion of each srcset entry
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.length);
+            param = param.slice(0, param.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+            
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+      });
+
+      describe('with a width parameter provided', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {w:100});
+
+        it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+          assert(srcset.split(",").length == 5);
+
+          var devicePixelRatios = srcset.split(",")
+          .map(function (srcsetSplit){
             return srcsetSplit.split(" ")[1];
           })
-          .map(function (width) {
-            return width.slice(0, -1);
-          })
-          .map(Number.parseFloat)
-        }();
-  
-        let prev = srcsetWidths[0];
-  
-        for (let index = 1; index < srcsetWidths.length; index++) {
-          var element = srcsetWidths[index];
-          assert((element / prev) < (1 + INCREMENT_ALLOWED));
-          prev = element;
-        }
-      });
-
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
-  
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          // split the url portion of each srcset entry
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
           
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.length);
-          param = param.slice(0, param.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
+          assert(devicePixelRatios[0] == '1x');
+          assert(devicePixelRatios[1] == '2x');
+          assert(devicePixelRatios[2] == '3x');
+          assert(devicePixelRatios[3] == '4x');
+          assert(devicePixelRatios[4] == '5x');
         });
-      });
-    });
 
-    describe('with a width parameter provided', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {w:100});
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
-        assert(srcset.split(",").length == 5);
-  
-        var devicePixelRatios = srcset.split(",")
-        .map(function (srcsetSplit){
-          return srcsetSplit.split(" ")[1];
-        })
-        
-        assert(devicePixelRatios[0] == '1x');
-        assert(devicePixelRatios[1] == '2x');
-        assert(devicePixelRatios[2] == '3x');
-        assert(devicePixelRatios[3] == '4x');
-        assert(devicePixelRatios[4] == '5x');
-      });
-
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
-
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
-          
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
-        });
-      });
-
-      it('should include a dpr param per specified src', function testSpec() {
-        
-        srclist = srcset.split(",");
-        for(var i = 0; i < srclist.length; i++)
-        {
-          src = srclist[i].split(" ")[0];
-          assert(src.includes(`dpr=${i+1}`));
-        }
-      });
-    });
-
-    describe('with a height parameter provided', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {h:100});
-
-      it('should generate the expected default srcset pair values', function testSpec(){
-        resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                       328, 380, 442, 512, 594, 688, 798, 926,
-                       1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                       3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
-        srclist = srcset.split(",");
-        src = srclist.map(function (srcline){
-          return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
-        })
-
-        for (var i = 0; i < srclist.length; i++) {
-          assert.equal(src[i], resolutions[i]);
-        }
-      });
-
-      it('should respect the height parameter', function testSpec(){
-        srcset.split(',').map(function (src) {
-          assert(src.includes('h='));
-        });
-      });
-
-      it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
-        assert.equal(srcset.split(',').length, 31);
-      });
-
-      it('should not exceed the bounds of [100, 8192]', function testSpec() {
-        var srcsetSplit = srcset.split(",");
-        var min = Number.parseFloat(
-          srcsetSplit[0]
-          .split(" ")[1]
-          .slice(0, -1)
-        );
-        var max = Number.parseFloat(
-          srcsetSplit[srcsetSplit.length-1]
-          .split(" ")[1]
-          .slice(0, -1)
-        );
-        assert(min >= 100);
-        assert(max <= 8192);
-      });
-
-      // a 17% testing threshold is used to account for rounding
-      it('should not increase more than 17% every iteration', function testSpec() {
-        var INCREMENT_ALLOWED = 0.17;
-        
-        var srcsetWidths = function() {
-          return srcset.split(",")
+          srcset.split(",")
           .map(function (srcsetSplit) {
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+            
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+            
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+
+        it('should include a dpr param per specified src', function testSpec() {
+          
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`dpr=${i+1}`));
+          }
+        });
+      });
+
+      describe('with a height parameter provided', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {h:100});
+
+        it('should generate the expected default srcset pair values', function testSpec(){
+          resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                         328, 380, 442, 512, 594, 688, 798, 926,
+                         1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                         3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+          srclist = srcset.split(",");
+          src = srclist.map(function (srcline){
+            return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+          })
+
+          for (var i = 0; i < srclist.length; i++) {
+            assert.equal(src[i], resolutions[i]);
+          }
+        });
+
+        it('should respect the height parameter', function testSpec(){
+          srcset.split(',').map(function (src) {
+            assert(src.includes('h='));
+          });
+        });
+
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.equal(srcset.split(',').length, 31);
+        });
+
+        it('should not exceed the bounds of [100, 8192]', function testSpec() {
+          var srcsetSplit = srcset.split(",");
+          var min = Number.parseFloat(
+            srcsetSplit[0]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          var max = Number.parseFloat(
+            srcsetSplit[srcsetSplit.length-1]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          assert(min >= 100);
+          assert(max <= 8192);
+        });
+
+        // a 17% testing threshold is used to account for rounding
+        it('should not increase more than 17% every iteration', function testSpec() {
+          var INCREMENT_ALLOWED = 0.17;
+          
+          var srcsetWidths = function() {
+            return srcset.split(",")
+            .map(function (srcsetSplit) {
+              return srcsetSplit.split(" ")[1];
+            })
+            .map(function (width) {
+              return width.slice(0, -1);
+            })
+            .map(Number.parseFloat)
+          }();
+
+          let prev = srcsetWidths[0];
+
+          for (let index = 1; index < srcsetWidths.length; index++) {
+            var element = srcsetWidths[index];
+            assert((element / prev) < (1 + INCREMENT_ALLOWED));
+            prev = element;
+          }
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
+
+          srcset.split(",")
+          .map(function (srcsetSplit) {
+            // split the url portion of each srcset entry
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.length);
+            param = param.slice(0, param.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+            
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+      });
+
+      describe('with a width and height parameter provided', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {w:100,h:100});
+
+        it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+          assert(srcset.split(",").length == 5);
+
+          var devicePixelRatios = srcset.split(",")
+          .map(function (srcsetSplit){
             return srcsetSplit.split(" ")[1];
           })
-          .map(function (width) {
-            return width.slice(0, -1);
-          })
-          .map(Number.parseFloat)
-        }();
-  
-        let prev = srcsetWidths[0];
-  
-        for (let index = 1; index < srcsetWidths.length; index++) {
-          var element = srcsetWidths[index];
-          assert((element / prev) < (1 + INCREMENT_ALLOWED));
-          prev = element;
-        }
-      });
-
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
-  
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          // split the url portion of each srcset entry
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
           
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.length);
-          param = param.slice(0, param.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
+          assert(devicePixelRatios[0] == '1x');
+          assert(devicePixelRatios[1] == '2x');
+          assert(devicePixelRatios[2] == '3x');
+          assert(devicePixelRatios[3] == '4x');
+          assert(devicePixelRatios[4] == '5x');
         });
-      });
-    });
 
-    describe('with a width and height parameter provided', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {w:100,h:100});
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
-        assert(srcset.split(",").length == 5);
-  
-        var devicePixelRatios = srcset.split(",")
-        .map(function (srcsetSplit){
-          return srcsetSplit.split(" ")[1];
-        })
-        
-        assert(devicePixelRatios[0] == '1x');
-        assert(devicePixelRatios[1] == '2x');
-        assert(devicePixelRatios[2] == '3x');
-        assert(devicePixelRatios[3] == '4x');
-        assert(devicePixelRatios[4] == '5x');
-      });
-
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
-  
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
-          
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
-        });
-      });
-
-      it('should include a dpr param per specified src', function testSpec() {
-        
-        srclist = srcset.split(",");
-        for(var i = 0; i < srclist.length; i++)
-        {
-          src = srclist[i].split(" ")[0];
-          assert(src.includes(`dpr=${i+1}`));
-        }
-      });
-    });
-
-    describe('with an aspect ratio parameter provided', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg',{ar:'3:2'});
-
-      it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
-        assert.equal(srcset.split(',').length, 31);
-      });
-
-      it('should generate the expected default srcset pair values', function testSpec(){
-        resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                       328, 380, 442, 512, 594, 688, 798, 926,
-                       1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                       3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
-        srclist = srcset.split(",");
-        src = srclist.map(function (srcline){
-          return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
-        })
-
-        for (var i = 0; i < srclist.length; i++) {
-          assert.equal(src[i], resolutions[i]);
-        }
-      });
-
-      it('should not exceed the bounds of [100, 8192]', function testSpec() {
-        var srcsetSplit = srcset.split(",");
-        var min = Number.parseFloat(
-          srcsetSplit[0]
-          .split(" ")[1]
-          .slice(0, -1)
-        );
-        var max = Number.parseFloat(
-          srcsetSplit[srcsetSplit.length-1]
-          .split(" ")[1]
-          .slice(0, -1)
-        );
-        assert(min >= 100);
-        assert(max <= 8192);
-      });
-
-      // a 17% testing threshold is used to account for rounding
-      it('should not increase more than 17% every iteration', function testSpec() {
-        var INCREMENT_ALLOWED = 0.17;
-        
-        var srcsetWidths = function() {
-          return srcset.split(",")
+          srcset.split(",")
           .map(function (srcsetSplit) {
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+            
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+
+        it('should include a dpr param per specified src', function testSpec() {
+          
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`dpr=${i+1}`));
+          }
+        });
+      });
+
+      describe('with an aspect ratio parameter provided', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg',{ar:'3:2'});
+
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.equal(srcset.split(',').length, 31);
+        });
+
+        it('should generate the expected default srcset pair values', function testSpec(){
+          resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                         328, 380, 442, 512, 594, 688, 798, 926,
+                         1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                         3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+          srclist = srcset.split(",");
+          src = srclist.map(function (srcline){
+            return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+          })
+
+          for (var i = 0; i < srclist.length; i++) {
+            assert.equal(src[i], resolutions[i]);
+          }
+        });
+
+        it('should not exceed the bounds of [100, 8192]', function testSpec() {
+          var srcsetSplit = srcset.split(",");
+          var min = Number.parseFloat(
+            srcsetSplit[0]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          var max = Number.parseFloat(
+            srcsetSplit[srcsetSplit.length-1]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          assert(min >= 100);
+          assert(max <= 8192);
+        });
+
+        // a 17% testing threshold is used to account for rounding
+        it('should not increase more than 17% every iteration', function testSpec() {
+          var INCREMENT_ALLOWED = 0.17;
+          
+          var srcsetWidths = function() {
+            return srcset.split(",")
+            .map(function (srcsetSplit) {
+              return srcsetSplit.split(" ")[1];
+            })
+            .map(function (width) {
+              return width.slice(0, -1);
+            })
+            .map(Number.parseFloat)
+          }();
+
+          let prev = srcsetWidths[0];
+
+          for (let index = 1; index < srcsetWidths.length; index++) {
+            var element = srcsetWidths[index];
+            assert((element / prev) < (1 + INCREMENT_ALLOWED));
+            prev = element;
+          }
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
+
+          srcset.split(",")
+          .map(function (srcsetSplit) {
+            // split the url portion of each srcset entry
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.length);
+            param = param.slice(0, param.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+      });
+
+      describe('with a width and aspect ratio parameter provided', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {w:100,ar:'3:2'});
+
+        it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+          assert(srcset.split(",").length == 5);
+
+          var devicePixelRatios = srcset.split(",")
+          .map(function (srcsetSplit){
             return srcsetSplit.split(" ")[1];
           })
-          .map(function (width) {
-            return width.slice(0, -1);
+
+          assert(devicePixelRatios[0] == '1x');
+          assert(devicePixelRatios[1] == '2x');
+          assert(devicePixelRatios[2] == '3x');
+          assert(devicePixelRatios[3] == '4x');
+          assert(devicePixelRatios[4] == '5x');
+        });
+
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
+
+          srcset.split(",")
+          .map(function (srcsetSplit) {
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+            
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+
+        it('should include a dpr param per specified src', function testSpec() {
+
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`dpr=${i+1}`));
+          }
+        });
+      });
+  
+      describe('with a height and aspect ratio parameter provided', function describeSuite() {
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {h:100,ar:'3:2'});
+
+        it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
+          assert(srcset.split(",").length == 5);
+
+          var devicePixelRatios = srcset.split(",")
+          .map(function (srcsetSplit){
+            return srcsetSplit.split(" ")[1];
           })
-          .map(Number.parseFloat)
-        }();
-  
-        let prev = srcsetWidths[0];
-  
-        for (let index = 1; index < srcsetWidths.length; index++) {
-          var element = srcsetWidths[index];
-          assert((element / prev) < (1 + INCREMENT_ALLOWED));
-          prev = element;
-        }
-      });
 
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
+          assert(devicePixelRatios[0] == '1x');
+          assert(devicePixelRatios[1] == '2x');
+          assert(devicePixelRatios[2] == '3x');
+          assert(devicePixelRatios[3] == '4x');
+          assert(devicePixelRatios[4] == '5x');
+        });
   
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          // split the url portion of each srcset entry
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
-          
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.length);
-          param = param.slice(0, param.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
+        it('should correctly sign each URL', function testSpec() {
+          var path = '/image.jpg';
+          var param, signatureBase, expected_signature;
+
+          srcset.split(",")
+          .map(function (srcsetSplit) {
+            return srcsetSplit.split(" ")[0];
+          }).map(function (src) {
+            // asserts that the expected 's=' parameter is being generated per entry
+            assert(src.includes("s="));
+
+            // param will have all params except for '&s=...'
+            param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
+            generated_signature = src.slice(src.indexOf('s=')+2, src.length)
+            signatureBase = 'MYT0KEN' + path + param;
+            expected_signature = md5(signatureBase);
+
+            assert.equal(expected_signature, generated_signature);
+          });
+        });
+  
+        it('should include a dpr param per specified src', function testSpec() {
+
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`dpr=${i+1}`));
+          }
         });
       });
     });
 
-    describe('with a width and aspect ratio parameter provided', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {w:100,ar:'3:2'});
+    describe('using srcset parameters', function describeSuite(){
+      describe('with a minWidth and/or maxWidth provided', function describeSuite() {
+        var MIN = 500;
+        var MAX = 2000;
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {}, {minWidth: MIN, maxWidth: MAX});
 
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
-        assert(srcset.split(",").length == 5);
-  
-        var devicePixelRatios = srcset.split(",")
-        .map(function (srcsetSplit){
-          return srcsetSplit.split(" ")[1];
-        })
-        
-        assert(devicePixelRatios[0] == '1x');
-        assert(devicePixelRatios[1] == '2x');
-        assert(devicePixelRatios[2] == '3x');
-        assert(devicePixelRatios[3] == '4x');
-        assert(devicePixelRatios[4] == '5x');
-      });
-
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
-  
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
-          
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.equal(srcset.split(',').length, 11);
         });
-      });
 
-      it('should include a dpr param per specified src', function testSpec() {
-        
-        srclist = srcset.split(",");
-        for(var i = 0; i < srclist.length; i++)
-        {
-          src = srclist[i].split(" ")[0];
-          assert(src.includes(`dpr=${i+1}`));
-        }
-      });
-    });
+        it('should generate the expected default srcset pair values', function testSpec(){
+          resolutions = [500, 580, 672, 780, 906, 1050, 1218, 1414, 1640, 1902, 2000];
+          srclist = srcset.split(",");
+          src = srclist.map(function (srcline){
+            return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+          })
 
-    describe('with a height and aspect ratio parameter provided', function describeSuite() {
-      var srcset = new ImgixClient({
-        domain: 'testing.imgix.net',
-        includeLibraryParam: false,
-        secureURLToken: 'MYT0KEN'
-      }).buildSrcSet('image.jpg', {h:100,ar:'3:2'});
-
-      it('should be in the form src 1x, src 2x, src 3x, src 4x, src 5x', function testSpec() {
-        assert(srcset.split(",").length == 5);
-  
-        var devicePixelRatios = srcset.split(",")
-        .map(function (srcsetSplit){
-          return srcsetSplit.split(" ")[1];
-        })
-        
-        assert(devicePixelRatios[0] == '1x');
-        assert(devicePixelRatios[1] == '2x');
-        assert(devicePixelRatios[2] == '3x');
-        assert(devicePixelRatios[3] == '4x');
-        assert(devicePixelRatios[4] == '5x');
-      });
-
-      it('should correctly sign each URL', function testSpec() {
-        var path = '/image.jpg';
-        var param, signatureBase, expected_signature;
-  
-        srcset.split(",")
-        .map(function (srcsetSplit) {
-          return srcsetSplit.split(" ")[0];
-        }).map(function (src) {
-          // asserts that the expected 's=' parameter is being generated per entry
-          assert(src.includes("s="));
-          
-          // param will have all params except for '&s=...'
-          param = src.slice(src.indexOf('?'), src.indexOf('s=')-1);
-          generated_signature = src.slice(src.indexOf('s=')+2, src.length)
-          signatureBase = 'MYT0KEN' + path + param;
-          expected_signature = md5(signatureBase);
-          
-          assert.equal(expected_signature, generated_signature);
+          for (var i = 0; i < srclist.length; i++) {
+            assert.equal(src[i], resolutions[i]);
+          }
         });
-      });
 
-      it('should include a dpr param per specified src', function testSpec() {
-        
-        srclist = srcset.split(",");
-        for(var i = 0; i < srclist.length; i++)
-        {
-          src = srclist[i].split(" ")[0];
-          assert(src.includes(`dpr=${i+1}`));
-        }
+        it('should not exceed the bounds of [100, 8192]', function testSpec() {
+          var srcsetSplit = srcset.split(",");
+          var min = Number.parseFloat(
+            srcsetSplit[0]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          var max = Number.parseFloat(
+            srcsetSplit[srcsetSplit.length-1]
+            .split(" ")[1]
+            .slice(0, -1)
+          );
+          assert(min >= MIN);
+          assert(max <= MAX);
+        });
+
+        it('errors with non-Number width', function testSpec() {
+          assert.throws(function() {
+            new ImgixClient({
+              domain: 'testing.imgix.net'
+            }).buildSrcSet('image.jpg', {}, {minWidth: 'abc'});
+          }, Error);
+        });
+
+        it('errors with negative width', function testSpec() {
+          assert.throws(function() {
+            new ImgixClient({
+              domain: 'testing.imgix.net'
+            }).buildSrcSet('image.jpg', {}, {maxWidth: -100});
+          }, Error);
+        });
+
+        it('does not include a minWidth or maxWidth URL parameter', function testSpec() {
+          assert(!srcset.includes('minWidth='))
+          assert(!srcset.includes('maxWidth='))
+        });
+
+        it('only includes one entry if maxWidth is equal to 100', function testSpec() {
+          var srcset = new ImgixClient({
+            domain: 'testing.imgix.net',
+            includeLibraryParam: false
+          }).buildSrcSet('image.jpg', {}, {maxWidth: 100})
+
+          assert.equal('https://testing.imgix.net/image.jpg?w=100 100w', srcset);
+        })
+
+        it('only includes one entry if minWidth is equal to 8192', function testSpec() {
+          var srcset = new ImgixClient({
+            domain: 'testing.imgix.net',
+            includeLibraryParam: false
+          }).buildSrcSet('image.jpg', {}, {minWidth: 8192})
+
+          assert.equal('https://testing.imgix.net/image.jpg?w=8192 8192w', srcset);
+        })
       });
     });
   });


### PR DESCRIPTION
This PR adds support to specify a minimum and/or maximum width range when generating `srcset` pairs. In certain situations where the exact min and/or max renderable sizes are known, a user may want to tailor their `srcset` list to be more concise. This is now possible by passing a positive integer value to either the `minWidth` or `maxWidth` parameters, now a part of a new second optional arguent when invoking `buildSrcSet()`. Below is a demonstration of the new argument in action:

```js
var client = new ImgixClient({
  domain:'testing.imgix.net',
  includeLibraryParam: false
  })
var srcset = client.buildSrcSet('image.jpg', {}, {minWidth:500, maxWidth: 2000})
```

This will generate a more specific `srcset` list as follows:

```html
https://testing.imgix.net/image.jpg?w=500 500w,
https://testing.imgix.net/image.jpg?w=580 580w,
https://testing.imgix.net/image.jpg?w=672 672w,
https://testing.imgix.net/image.jpg?w=780 780w,
https://testing.imgix.net/image.jpg?w=906 906w,
https://testing.imgix.net/image.jpg?w=1050 1050w,
https://testing.imgix.net/image.jpg?w=1218 1218w,
https://testing.imgix.net/image.jpg?w=1414 1414w,
https://testing.imgix.net/image.jpg?w=1640 1640w,
https://testing.imgix.net/image.jpg?w=1902 1902w,
https://testing.imgix.net/image.jpg?w=2000 2000w
```