### PR TITLE
feat: add support for defining a custom srcset width tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [In-browser](#in-browser)
 - [Srcset Generation](#srcset-generation)
   - [Fixed image rendering](#fixed-image-rendering)
+  - [Width Tolerance](#width-tolerance)
   - [Minimum and Maximum Width Ranges](#minimum-and-maximum-width-ranges)
 - [What is the `ixlib` param on every request?](#what-is-the-ixlib-param-on-every-request)
 - [Testing](#testing)
@@ -129,6 +130,32 @@ https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=5&s=7c4b8adb733d
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
+### Width Tolerance
+
+The `srcset` width tolerance dictates the maximum tolerated size difference between an image's downloaded size and its rendered size. For example: setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate. A lower tolerance means images will render closer to their native size (thereby reducing rendering artifacts), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
+
+By default this rate is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by providing a positive scalar value as `widthTolerance` to the third options object:
+
+```js
+var client = new ImgixClient({
+  domain:'testing.imgix.net',
+  includeLibraryParam: false
+  })
+var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: .20})
+
+console.log(srcset);
+```
+
+In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:
+
+```html
+https://testing.imgix.net/image.jpg?w=100 100w,
+https://testing.imgix.net/image.jpg?w=140 140w,
+https://testing.imgix.net/image.jpg?w=196 196w,
+							...
+https://testing.imgix.net/image.jpg?w=8192 8192w
+```
 
 ### Minimum and Maximum Width Ranges
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For more information to better understand `srcset`, we highly recommend [Eric Po
 
 ### Width Tolerance
 
-The `srcset` width tolerance dictates the maximum tolerated size difference between an image's downloaded size and its rendered size. For example: setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate. A lower tolerance means images will render closer to their native size (thereby reducing rendering artifacts), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
+The `srcset` width tolerance dictates the maximum tolerated size difference between an image's downloaded size and its rendered size. For example: setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate. A lower tolerance means images will render closer to their native size (thereby increasing perceived image quality), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
 
 By default this rate is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by providing a positive scalar value as `widthTolerance` to the third options object:
 
@@ -142,7 +142,7 @@ var client = new ImgixClient({
   domain:'testing.imgix.net',
   includeLibraryParam: false
   })
-var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: .20})
+var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.20})
 
 console.log(srcset);
 ```

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -21,13 +21,15 @@
   var MIN_SRCSET_WIDTH = 100;
   // maximum generated srcset width
   var MAX_SRCSET_WIDTH = 8192;
+  // default tolerable percent difference between srcset pair widths
+  var DEFAULT_SRCSET_WIDTH_TOLERANCE = .08;
   // returns an array of width values used during srcset generation
-  var DEFAULT_SRCSET_WIDTHS = _generateTargetWidths(MIN_SRCSET_WIDTH, MAX_SRCSET_WIDTH);
+  var DEFAULT_SRCSET_WIDTHS = _generateTargetWidths(DEFAULT_SRCSET_WIDTH_TOLERANCE, MIN_SRCSET_WIDTH, MAX_SRCSET_WIDTH);
 
   // returns an array of width values used during scrset generation
-  function _generateTargetWidths(minWidth, maxWidth) {
+  function _generateTargetWidths(widthTolerance, minWidth, maxWidth) {
     var resolutions = [];
-    var INCREMENT_PERCENTAGE = 8;
+    var INCREMENT_PERCENTAGE = widthTolerance;
     var minWidth = Math.floor(minWidth);
     var maxWidth = Math.floor(maxWidth);
 
@@ -38,7 +40,7 @@
     var prev = minWidth;
     while (prev < maxWidth) {
       resolutions.push(ensureEven(prev));
-      prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
+      prev *= 1 + (INCREMENT_PERCENTAGE * 2);
     }
 
     resolutions.push(maxWidth);
@@ -174,12 +176,14 @@
       var srcset = '';
       var currentWidth;
       var targetWidths;
+      var widthTolerance = options["widthTolerance"] || DEFAULT_SRCSET_WIDTH_TOLERANCE;
       var minWidth = options["minWidth"] || MIN_SRCSET_WIDTH;
       var maxWidth = options["maxWidth"] || MAX_SRCSET_WIDTH;
 
-      if (minWidth != MIN_SRCSET_WIDTH || maxWidth != MAX_SRCSET_WIDTH) {
+      if (widthTolerance != DEFAULT_SRCSET_WIDTH_TOLERANCE || minWidth != MIN_SRCSET_WIDTH || maxWidth != MAX_SRCSET_WIDTH) {
         validateRange(minWidth, maxWidth);
-        targetWidths = _generateTargetWidths(minWidth, maxWidth);
+        validateWidthTolerance(widthTolerance);
+        targetWidths = _generateTargetWidths(widthTolerance, minWidth, maxWidth);
       }
       else {
         targetWidths = DEFAULT_SRCSET_WIDTHS;
@@ -213,6 +217,12 @@
           throw new Error('The min and max srcset widths must be passed positive Number values');
       }
     };
+
+    function validateWidthTolerance(widthTolerance) {
+      if (typeof widthTolerance != 'number' || widthTolerance < 0) {
+        throw new Error('The srcset widthTolerance argument must be passed a positive scalar number');
+      }
+    }
 
     ImgixClient.VERSION = VERSION;
 


### PR DESCRIPTION
This PR adds logic which will allow users to modify the width tolerance used when building `srcset` width pairs. More specifically, the width tolerance dictates the maximum difference between entries in a `srcset` attribute that should be generated. By default, this rate is set to 8 (`0.08`) percent. Users can use this setting to fine tune how many `srcset` pairs they generate when calling `buildSrcSet()`.

A user can now specify their own tolerance rate by passing a positive scalar value to the `widthTolerance` within the method's optional third argument. See the following example:

```js
var client = new ImgixClient({
  domain:'testing.imgix.net',
  includeLibraryParam: false
  })
var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: .20})

console.log(srcset);
```
In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a `srcset` pair:
```
https://testing.imgix.net/image.jpg?w=100 100w,
https://testing.imgix.net/image.jpg?w=140 140w,
https://testing.imgix.net/image.jpg?w=196 196w,
							...
https://testing.imgix.net/image.jpg?w=8192 8192w
```