### PR TITLE
feat: add support for defining a custom srcset width array

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [In-browser](#in-browser)
 - [Srcset Generation](#srcset-generation)
   - [Fixed image rendering](#fixed-image-rendering)
+  - [Custom Widths](#custom-widths)
   - [Width Tolerance](#width-tolerance)
   - [Minimum and Maximum Width Ranges](#minimum-and-maximum-width-ranges)
 - [What is the `ixlib` param on every request?](#what-is-the-ixlib-param-on-every-request)
@@ -130,6 +131,31 @@ https://testing.imgix.net/image.jpg?h=800&ar=3%3A2&fit=crop&dpr=5&s=7c4b8adb733d
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
+### Custom Widths
+
+In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of positive integers as `widths` to the third options object:
+
+```js
+var client = new ImgixClient({
+  domain:'testing.imgix.net',
+  includeLibraryParam: false
+  })
+var srcset = client.buildSrcSet('image.jpg', {}, {widths: [100, 500, 1000, 1800]})
+
+console.log(srcset);
+```
+
+Will generate the following `srcset` of width pairs:
+
+```html
+https://testing.imgix.net/image.jpg?w=100 100w,
+https://testing.imgix.net/image.jpg?w=500 500w,
+https://testing.imgix.net/image.jpg?w=1000 1000w,
+https://testing.imgix.net/image.jpg?w=1800 1800w
+```
+
+Please note that in situations where a `srcset` is being rendered as a [fixed image](#fixed-image-rendering), any custom `widths` passed in will be ignored. Additionally, if both `widths` and a `widthTolerance` are passed to the `buildSrcSet` method, the custom widths list will take precedence.
 
 ### Width Tolerance
 

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -179,8 +179,13 @@
       var widthTolerance = options["widthTolerance"] || DEFAULT_SRCSET_WIDTH_TOLERANCE;
       var minWidth = options["minWidth"] || MIN_SRCSET_WIDTH;
       var maxWidth = options["maxWidth"] || MAX_SRCSET_WIDTH;
+      var customWidths = options["widths"];
 
-      if (widthTolerance != DEFAULT_SRCSET_WIDTH_TOLERANCE || minWidth != MIN_SRCSET_WIDTH || maxWidth != MAX_SRCSET_WIDTH) {
+      if (customWidths) {
+        validateWidths(customWidths);
+        targetWidths = customWidths;
+      }
+      else if (widthTolerance != DEFAULT_SRCSET_WIDTH_TOLERANCE || minWidth != MIN_SRCSET_WIDTH || maxWidth != MAX_SRCSET_WIDTH) {
         validateRange(minWidth, maxWidth);
         validateWidthTolerance(widthTolerance);
         targetWidths = _generateTargetWidths(widthTolerance, minWidth, maxWidth);
@@ -213,7 +218,7 @@
     };
 
     function validateRange(min, max) {
-      if (!(typeof min == 'number' && typeof max == 'number') || (min < 0 || max < 0)) {
+      if (!(Number.isInteger(min) && Number.isInteger(max)) || (min < 0 || max < 0)) {
           throw new Error('The min and max srcset widths must be passed positive Number values');
       }
     };
@@ -221,6 +226,22 @@
     function validateWidthTolerance(widthTolerance) {
       if (typeof widthTolerance != 'number' || widthTolerance < 0) {
         throw new Error('The srcset widthTolerance argument must be passed a positive scalar number');
+      }
+    }
+
+    function validateWidths(customWidths) {
+      if (!Array.isArray(customWidths) || !customWidths.length) {
+        throw new Error('The widths argument must be passed a valid non-empty array of integers');
+      }
+      else {
+        allPositiveIntegers = customWidths.every(
+          function(width) {
+            return Number.isInteger(width) && width > 0
+          }
+        );
+        if (!allPositiveIntegers) {
+          throw new Error('A custom widths argument can only contain positive integer values');
+        }
       }
     }
 

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -1025,6 +1025,55 @@ describe('Imgix client:', function describeSuite() {
           }, Error);
         });
       });
+
+      describe('with a custom list of widths provided', function describeSuite() {
+        var CUSTOM_WIDTHS = [100, 500, 1000, 1800];
+        var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false,
+          secureURLToken: 'MYT0KEN'
+        }).buildSrcSet('image.jpg', {}, {widths:CUSTOM_WIDTHS});
+
+        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
+          assert.equal(srcset.split(',').length, 4);
+        });
+
+        it('should generate the expected default srcset pair values', function testSpec(){
+          resolutions = CUSTOM_WIDTHS;
+          srclist = srcset.split(",");
+          src = srclist.map(function (srcline){
+            return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+          })
+
+          for (var i = 0; i < srclist.length; i++) {
+            assert.equal(src[i], resolutions[i]);
+          }
+        });
+
+        it('errors with non-array argument', function testSpec() {
+          assert.throws(function() {
+            new ImgixClient({
+              domain: 'testing.imgix.net'
+            }).buildSrcSet('image.jpg', {}, {widths: 'abc'});
+          }, Error);
+        });
+
+        it('errors with non-positive value passed in to the argument', function testSpec() {
+          assert.throws(function() {
+            new ImgixClient({
+              domain: 'testing.imgix.net'
+            }).buildSrcSet('image.jpg', {}, {widths: [100, -200]});
+          }, Error);
+        });
+
+        it('errors with non-integer value passed in to the argument', function testSpec() {
+          assert.throws(function() {
+            new ImgixClient({
+              domain: 'testing.imgix.net'
+            }).buildSrcSet('image.jpg', {}, {widths: [100, false]});
+          }, Error);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds logic that allows users to pass in a custom widths list when generating `srcset` pairs.
In certain cases when users know exactly what widths they want to have their images rendered at, they will be able to pass in an array of positive integers as `widths` to the optional third object:

```js
var client = new ImgixClient({
  domain:'testing.imgix.net',
  includeLibraryParam: false
  })
var srcset = client.buildSrcSet('image.jpg', {}, {widths: [100, 500, 1000, 1800]})

console.log(srcset);
```

Will generate the following `srcset` of width pairs:

```html
https://testing.imgix.net/image.jpg?w=100 100w,
https://testing.imgix.net/image.jpg?w=500 500w,
https://testing.imgix.net/image.jpg?w=1000 1000w,
https://testing.imgix.net/image.jpg?w=1800 1800w
```

It is important to note that in situations where a `srcset` is being rendered as a fixed image, any custom `widths` passed in will be ignored. Additionally, if both `widths` and a `widthTolerance` are passed in to the `buildSrcSet()` method, the custom widths list will take precedence.