### PR TITLE
feat: append variable qualities to dpr srcsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   - [Custom Widths](#custom-widths)
   - [Width Tolerance](#width-tolerance)
   - [Minimum and Maximum Width Ranges](#minimum-and-maximum-width-ranges)
+  - [Variable Qualities](#variable-qualities)
 - [What is the `ixlib` param on every request?](#what-is-the-ixlib-param-on-every-request)
 - [Testing](#testing)
 
@@ -216,6 +217,31 @@ https://testing.imgix.net/image.jpg?w=2000 2000w
 Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_srcset: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
 
 Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
+
+### Variable Qualities
+
+This library will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a [fixed-image](https://github.com/imgix/imgix-core-js#fixed-image-rendering) srcset. This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality).
+
+This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `{ disableVariableQuality: true }` to the third argument of `buildSrcSet()`.
+
+This behavior specifically occurs when a [fixed-size image](https://github.com/imgix/imgix-core-js#fixed-image-rendering) is rendered, for example:
+
+```js
+var srcset = new ImgixClient({
+          domain: 'testing.imgix.net',
+          includeLibraryParam: false
+        }).buildSrcSet('image.jpg', {w:100});
+```
+
+will generate a srcset with the following `q` to `dpr` mapping:
+
+```html
+https://testing.imgix.net/image.jpg?w=100&dpr=1&q=75 1x,
+https://testing.imgix.net/image.jpg?w=100&dpr=2&q=50 2x,
+https://testing.imgix.net/image.jpg?w=100&dpr=3&q=35 3x,
+https://testing.imgix.net/image.jpg?w=100&dpr=4&q=23 4x,
+https://testing.imgix.net/image.jpg?w=100&dpr=5&q=20 5x
+```
 
 ## What is the `ixlib` param on every request?
 

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -463,6 +463,7 @@ describe('Imgix client:', function describeSuite() {
       });
 
       describe('with a width parameter provided', function describeSuite() {
+        var DPR_QUALITY = [75, 50, 35, 23, 20];
         var srcset = new ImgixClient({
           domain: 'testing.imgix.net',
           includeLibraryParam: false,
@@ -506,12 +507,52 @@ describe('Imgix client:', function describeSuite() {
         });
 
         it('should include a dpr param per specified src', function testSpec() {
-          
           srclist = srcset.split(",");
           for(var i = 0; i < srclist.length; i++)
           {
             src = srclist[i].split(" ")[0];
             assert(src.includes(`dpr=${i+1}`));
+          }
+        });
+
+        it('should include variable qualities by default', function testSpec() {
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${DPR_QUALITY[i]}`));
+          }
+        });
+
+        it('should override the variable quality if a quality parameter is provided', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
+          }
+        });
+
+        it('should correctly disable generated variable qualities via the \'disableVariableQuality\' argument', function testSpec() {
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(!src.includes(`q=`));
+          }
+        });
+
+        it('should respect a provided quality parameter when variable qualities are disabled', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
           }
         });
       });
@@ -613,6 +654,7 @@ describe('Imgix client:', function describeSuite() {
       });
 
       describe('with a width and height parameter provided', function describeSuite() {
+        var DPR_QUALITY = [75, 50, 35, 23, 20];
         var srcset = new ImgixClient({
           domain: 'testing.imgix.net',
           includeLibraryParam: false,
@@ -662,6 +704,47 @@ describe('Imgix client:', function describeSuite() {
           {
             src = srclist[i].split(" ")[0];
             assert(src.includes(`dpr=${i+1}`));
+          }
+        });
+
+        it('should include variable qualities by default', function testSpec() {
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${DPR_QUALITY[i]}`));
+          }
+        });
+
+        it('should override the variable quality if a quality parameter is provided', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
+          }
+        });
+
+        it('should correctly disable generated variable qualities via the \'disableVariableQuality\' argument', function testSpec() {
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(!src.includes(`q=`));
+          }
+        });
+
+        it('should respect a provided quality parameter when variable qualities are disabled', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
           }
         });
       });
@@ -757,6 +840,7 @@ describe('Imgix client:', function describeSuite() {
       });
 
       describe('with a width and aspect ratio parameter provided', function describeSuite() {
+        var DPR_QUALITY = [75, 50, 35, 23, 20];
         var srcset = new ImgixClient({
           domain: 'testing.imgix.net',
           includeLibraryParam: false,
@@ -808,9 +892,51 @@ describe('Imgix client:', function describeSuite() {
             assert(src.includes(`dpr=${i+1}`));
           }
         });
+
+        it('should include variable qualities by default', function testSpec() {
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${DPR_QUALITY[i]}`));
+          }
+        });
+
+        it('should override the variable quality if a quality parameter is provided', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
+          }
+        });
+
+        it('should correctly disable generated variable qualities via the \'disableVariableQuality\' argument', function testSpec() {
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(!src.includes(`q=`));
+          }
+        });
+
+        it('should respect a provided quality parameter when variable qualities are disabled', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
+          }
+        });
       });
   
       describe('with a height and aspect ratio parameter provided', function describeSuite() {
+        var DPR_QUALITY = [75, 50, 35, 23, 20];
         var srcset = new ImgixClient({
           domain: 'testing.imgix.net',
           includeLibraryParam: false,
@@ -860,6 +986,47 @@ describe('Imgix client:', function describeSuite() {
           {
             src = srclist[i].split(" ")[0];
             assert(src.includes(`dpr=${i+1}`));
+          }
+        });
+
+        it('should include variable qualities by default', function testSpec() {
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${DPR_QUALITY[i]}`));
+          }
+        });
+
+        it('should override the variable quality if a quality parameter is provided', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
+          }
+        });
+
+        it('should correctly disable generated variable qualities via the \'disableVariableQuality\' argument', function testSpec() {
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(!src.includes(`q=`));
+          }
+        });
+
+        it('should respect a provided quality parameter when variable qualities are disabled', function testSpec() {
+          var QUALITY_OVERRIDE = 100;
+          var srcset = new ImgixClient({domain: 'testing.imgix.net'}).buildSrcSet('image.jpg', {w:800, q:QUALITY_OVERRIDE}, {disableVariableQuality: true});
+          srclist = srcset.split(",");
+          for(var i = 0; i < srclist.length; i++)
+          {
+            src = srclist[i].split(" ")[0];
+            assert(src.includes(`q=${QUALITY_OVERRIDE}`));
           }
         });
       });


### PR DESCRIPTION
This library will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a [fixed-image](https://github.com/imgix/imgix-core-js#fixed-image-rendering) srcset. This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality).

This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `{ disableVariableQuality: true }` to the third argument of `buildSrcSet()`.

The following map of `q` to `dpr` pairs will be generated:

`dpr` | `q`
--- |---
1 | 75 
2 | 50 
3 | 35 
4 | 23 
5 | 20 

This behavior specifically occurs when a [fixed-size image](https://github.com/imgix/imgix-core-js#fixed-image-rendering) is rendered, for example:

```js
var srcset = new ImgixClient({
          domain: 'testing.imgix.net',
          includeLibraryParam: false
        }).buildSrcSet('image.jpg', {w:100});
```

will generate a srcset with the following `q` to `dpr` mapping:

```html
https://testing.imgix.net/image.jpg?w=100&dpr=1&q=75 1x,
https://testing.imgix.net/image.jpg?w=100&dpr=2&q=50 2x,
https://testing.imgix.net/image.jpg?w=100&dpr=3&q=35 3x,
https://testing.imgix.net/image.jpg?w=100&dpr=4&q=23 4x,
https://testing.imgix.net/image.jpg?w=100&dpr=5&q=20 5x
```