### PR TITLE
feat: add srcset option parameter to buildSrcSet() method signature

### DIFF
--- a/src/imgix-core-js.d.ts
+++ b/src/imgix-core-js.d.ts
@@ -13,8 +13,8 @@ declare class ImgixClient {
     _sanitizePath(path: string): string;
     _buildParams(params: {}): string;
     _signParams(path: string, queryParams?: {}): string;
-    buildSrcSet(path: string, params?: {}): string;
-    _buildSrcSetPairs(path: string, params?: {}): string;
-    _buildDPRSrcSet(path: string, params?: {}): string;
+    buildSrcSet(path: string, params?: {}, options?: {}): string;
+    _buildSrcSetPairs(path: string, params?: {}, options?: {}): string;
+    _buildDPRSrcSet(path: string, params?: {}, options?: {}): string;
 }
 export = ImgixClient;

--- a/src/imgix-core-js.d.ts
+++ b/src/imgix-core-js.d.ts
@@ -8,13 +8,22 @@ declare class ImgixClient {
 
     constructor(opts: {domain: string; secureURLToken?: string; useHTTPS?: boolean; includeLibraryParam?: boolean;});
 
-
     buildURL(path: string, params?: {}): string;
     _sanitizePath(path: string): string;
     _buildParams(params: {}): string;
     _signParams(path: string, queryParams?: {}): string;
-    buildSrcSet(path: string, params?: {}, options?: {}): string;
-    _buildSrcSetPairs(path: string, params?: {}, options?: {}): string;
-    _buildDPRSrcSet(path: string, params?: {}, options?: {}): string;
+    buildSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
+    _buildSrcSetPairs(path: string, params?: {}, options?: SrcSetOptions): string;
+    _buildDPRSrcSet(path: string, params?: {}, options?: SrcSetOptions): string;
+
+}    
+
+interface SrcSetOptions {
+    widths?: number[];
+    widthTolerance?: number;
+    minWidth?: number;
+    maxWidth?: number;
+    disableVariableQuality?: boolean;
 }
+
 export = ImgixClient;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "umd",
         "types": [
             "node"
-         ]
+        ]
     },
     "files": [
         "src/imgix-core-js.d.ts"


### PR DESCRIPTION
This PR adds TS definitions for the `srcset` modifier argument used in the `buildSrcSet()` method, which grants users the capability to fine-tune how their `srcset` value is generated. As part of this, we are able to provide users with an interface describing the available arguments that can be passed into this option, mapped to their expected variable types. Below is an example of intellisense completion listing these available arguments from a user's point of view.


<img width="1184" alt="Screen Shot 2020-03-03 at 5 13 30 PM" src="https://user-images.githubusercontent.com/15919091/75834925-54e26700-5d72-11ea-8ec9-c89fccd5569b.png">


Relates to #108, #109, #110, #111 