### PR TITLE
test: explicitly test overriding libraryParam for imgix SDKs

### DIFF
--- a/test/test-sdk-api.js
+++ b/test/test-sdk-api.js
@@ -1,0 +1,16 @@
+var assert = require("assert");
+var ImgixClient = require("../src/imgix-core-js");
+
+describe("imgix-core-js + SDK library API:", function () {
+  it("allows an SDK library to override libraryParam", () => {
+    const client = new ImgixClient({
+      domain: "testing.imgix.net",
+    });
+
+    client.settings.libraryParam = "test";
+
+    result = client._buildParams({});
+
+    assert(result.match(/ixlib=test/));
+  });
+});


### PR DESCRIPTION
I made this PR because we are using this pseudo-public API in our Angular and Vue libraries (and probably others) to set `ixlib` to the correct value for that library. I thought it would be good idea to explicitly state this as a "imgix-public" API that we can depend on in SDK libraries, so we don't end up changing this library and breaking this API, and only realising down the track when we pull this library into other SDKs.