### PR TITLE
build: drop support for Node.js 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 before_install:
 - npm install -g npm@latest
 node_js:
-- '8.0'
 - '10.0'
 - '12.0'
+- '13.0'
+


### PR DESCRIPTION
This PR moves this project away from building for Node.js v8.x as it reached [EOL](https://endoflife.software/programming-languages/server-side-scripting/nodejs) in December 2019. This also offers the secondary benefit of allowing us to utilize more [ECMA2015 features](https://node.green/) moving forward.

Unblocks #99 