### PR TITLE
chore: call-out @imgix/imgix-sdk-team in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please provide the following information and someone from @imgix/imgix-sdk-team will respond to your issue shortly.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please provide the following information and someone from @imgix/imgix-sdk-team will respond to your issue shortly.
+
 **Before you submit:**
 
 - [ ] Please search through the [existing issues](https://github.com/imgix/imgix-core-js/issues?utf8=%E2%9C%93&q=is%3Aissue) to see if your feature has already been discussed.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Please provide the following information and someone from @imgix/imgix-sdk-team will respond to your issue shortly.
+
 **Before you submit:**
 
 - [ ] Please search through the [existing issues]([existing issues](https://github.com/imgix/imgix-core-js/issues?utf8=%E2%9C%93&q=is%3Aissue)) to see if your question has already been discussed.


### PR DESCRIPTION
GitHub issue templates can only be auto-assigned to individual users, but unfortunately not teams. As a middle ground, we decided to include a line in the template body specifically mentioning the @imgix/ imgix-sdk-team team so users know who to expect a response from.

----------

<img width="782" alt="Screen Shot 2020-07-21 at 11 13 47 AM" src="https://user-images.githubusercontent.com/15919091/88090982-417a4180-cb43-11ea-9431-20c25c9fea13.png">