### PR TITLE
chore: add project CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for repo
+*       @imgix/imgix-sdk-team


### PR DESCRIPTION
This PR adds [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) to designate those responsible for maintaining this project to outside users/contributors. Currently, the default/only assignment points to @imgix/imgix-sdk-team.