### PR TITLE
fix(buildSrcSet): ensure operation is idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
         + [Width Tolerance](#width-tolerance)
         + [Minimum and Maximum Width Ranges](#minimum-and-maximum-width-ranges)
         + [Variable Qualities](#variable-qualities)
+    * [Web Proxy Sources](#web-proxy-sources)
 - [What is the `Ixlib` Param on Every Request?](#what-is-the-ixlib-param-on-every-request)
 - [Testing](#testing)
 
@@ -331,6 +332,22 @@ https://testing.imgix.net/image.jpg?w=100&dpr=2&q=50 2x,
 https://testing.imgix.net/image.jpg?w=100&dpr=3&q=35 3x,
 https://testing.imgix.net/image.jpg?w=100&dpr=4&q=23 4x,
 https://testing.imgix.net/image.jpg?w=100&dpr=5&q=20 5x
+```
+
+### Web Proxy Sources
+
+If you are using a [Web Proxy Source](https://docs.imgix.com/setup/creating-sources/web-proxy), all you need to do is pass the full image URL you would like to proxy to `imgix-core-js` as the path, and include a `secureURLToken` when creating the client. `imgix-core-js` will then encode this full URL into a format that imgix will understand, thus creating a proxy URL for you.
+
+```js
+import ImgixClient from 'imgix-core-js';
+
+const client = new ImgixClient({
+  domain: 'my-proxy-domain.imgix.net',
+  secureURLToken: '<token>',
+});
+
+client.buildURL('https://example.com/image-to-proxy.jpg', {});
+client.buildSrcSet('https://example.com/image-to-proxy.jpg', {});
 ```
 
 ## What is the `Ixlib` Param on Every Request?

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,9 +425,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
     "locate-path": {
@@ -728,9 +728,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
-      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.1.0.tgz",
+      "integrity": "sha512-9zQShgaeylYH6qtsnNXlTvv0FGTTckuDfHBi+qhgj5PvW2r2WslHZpgc3uy3e/ZAoPkqaOASPi+juU6EdYRYxA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.2",
@@ -755,9 +755,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/node": "12.12.31",
     "benchmark": "2.1.4",
     "mocha": "6.2.2",
-    "sinon": "9.0.3",
+    "sinon": "9.1.0",
     "typescript": "4.0.3",
     "uglify-js": "3.11.0"
   },

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -107,11 +107,11 @@
     };
 
     ImgixClient.prototype._buildParams = function(params) {
+      var queryParams = [];
       if (this.settings.libraryParam) {
-        params.ixlib = this.settings.libraryParam
+        queryParams.push('ixlib=' + this.settings.libraryParam)
       }
 
-      var queryParams = [];
       var key, val, encodedKey, encodedVal;
       for (key in params) {
         val = params[key];
@@ -174,10 +174,16 @@
         targetWidths = this._generateTargetWidths(widthTolerance, minWidth, maxWidth);
       }
 
+      var queryParams = {};
+      var key;
+      for (key in params) {
+        queryParams[key] = params[key];
+      }
+
       for (var i = 0; i < targetWidths.length; i++) {
         currentWidth = targetWidths[i];
-        params.w = currentWidth;
-        srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
+        queryParams.w = currentWidth;
+        srcset += this.buildURL(path, queryParams) + ' ' + currentWidth + 'w,\n';
       }
 
       return srcset.slice(0,-2);
@@ -186,23 +192,29 @@
     ImgixClient.prototype._buildDPRSrcSet = function(path, params, options) {
         var srcset = '';
         var targetRatios = [1, 2, 3, 4, 5];
-        var currentRatio;
         var disableVariableQuality = options.disableVariableQuality || false;
-        var quality = params.q;
+
+        var key;
+        var queryParams = {};
+        for (key in params) {
+          queryParams[key] = params[key];
+        }
+
+        var quality = queryParams.q;
 
         if (!disableVariableQuality) {
           validateVariableQuality(disableVariableQuality);
         }
 
         for (var i = 0; i < targetRatios.length; i++) {
-          currentRatio = targetRatios[i];
-          params.dpr = currentRatio;
+          var currentRatio = targetRatios[i];
+          queryParams.dpr = currentRatio;
 
           if (!disableVariableQuality) {
-            params.q = quality || DPR_QUALITIES[currentRatio];
+            queryParams.q = quality || DPR_QUALITIES[currentRatio];
           }
 
-          srcset += this.buildURL(path, params) + ' ' + currentRatio + 'x,\n'
+          srcset += this.buildURL(path, queryParams) + ' ' + currentRatio + 'x,\n'
         }
 
         return srcset.slice(0,-2);

--- a/test/test-buildSrcSet.js
+++ b/test/test-buildSrcSet.js
@@ -387,6 +387,21 @@ describe('SrcSet Builder:', function describeSuite() {
                         assert(src.includes(`q=${QUALITY_OVERRIDE}`));
                     }
                 });
+
+                it('should not modify input params and should be idempotent', function testSpec() {
+                    var client = new ImgixClient({ domain: 'test.imgix.net' });
+                    var params = {};
+                    var srcsetOptions = { widths: [100] };
+                    var srcset1 = client.buildSrcSet('', params, srcsetOptions);
+                    var srcset2 = client.buildSrcSet('', params, srcsetOptions);
+
+                    // Show idempotent, ie. calling buildSrcSet produces the same result given
+                    // the same input-parameters.
+                    assert(srcset1 == srcset2);
+
+                    // Assert that the object remains unchanged.
+                    assert(Object.keys(params).length === 0 && params.constructor === Object);
+                });
             });
 
             describe('with an aspect ratio parameter provided', function describeSuite() {

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -227,7 +227,7 @@ describe('URL Builder:', function describeSuite() {
             var params = {
                     w: 400
                 },
-                expectation = '?w=400&ixlib=test',
+                expectation = '?ixlib=test&w=400',
                 result;
 
             client.settings.libraryParam = 'test';


### PR DESCRIPTION
The purpose of this PR is to ensure the `buildSrcSet` operation is
idempotent. Prior to this PR, code modified the input-parameters,
`params`, causing identical calls to `buildSrcSet` to produce different
results.

Now, the input `params` are copied into a new `queryParams` object and
this object is passed to callers requiring `params`. A test has been
written to show that the behavior has changed from the behavior detailed
in issue #158––the input `params` object remains unchanged after calling
`buildSrcSet` _and_ that calling `buildSrcSet` multiple times produces
the same result (given the same inputs).

I also ripgrep'd through the repo with `rg 'params.[:alpha:]'` and with
`rg 'params\['` to ensure `params` is never mutated (i.e. it never
appears on the left hand side of any expression).

Closes #158 