### PR TITLE
fix(buildURL): ensure operation is idempotent

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -107,11 +107,11 @@
     };
 
     ImgixClient.prototype._buildParams = function(params) {
+      var queryParams = [];
       if (this.settings.libraryParam) {
-        params.ixlib = this.settings.libraryParam
+        queryParams.push('ixlib=' + this.settings.libraryParam)
       }
 
-      var queryParams = [];
       var key, val, encodedKey, encodedVal;
       for (key in params) {
         val = params[key];
@@ -174,10 +174,16 @@
         targetWidths = this._generateTargetWidths(widthTolerance, minWidth, maxWidth);
       }
 
+      var key;
+      var queryParams = {};
+      for (key in params) {
+        queryParams[key] = params[key];
+      }
+
       for (var i = 0; i < targetWidths.length; i++) {
         currentWidth = targetWidths[i];
-        params.w = currentWidth;
-        srcset += this.buildURL(path, params) + ' ' + currentWidth + 'w,\n';
+        queryParams.w = currentWidth;
+        srcset += this.buildURL(path, queryParams) + ' ' + currentWidth + 'w,\n';
       }
 
       return srcset.slice(0,-2);
@@ -186,23 +192,29 @@
     ImgixClient.prototype._buildDPRSrcSet = function(path, params, options) {
         var srcset = '';
         var targetRatios = [1, 2, 3, 4, 5];
-        var currentRatio;
         var disableVariableQuality = options.disableVariableQuality || false;
-        var quality = params.q;
+
+        var key;
+        var queryParams = {};
+        for (key in params) {
+          queryParams[key] = params[key];
+        }
+
+        var quality = queryParams.q;
 
         if (!disableVariableQuality) {
           validateVariableQuality(disableVariableQuality);
         }
 
         for (var i = 0; i < targetRatios.length; i++) {
-          currentRatio = targetRatios[i];
-          params.dpr = currentRatio;
+          var currentRatio = targetRatios[i];
+          queryParams.dpr = currentRatio;
 
           if (!disableVariableQuality) {
-            params.q = quality || DPR_QUALITIES[currentRatio];
+            queryParams.q = quality || DPR_QUALITIES[currentRatio];
           }
 
-          srcset += this.buildURL(path, params) + ' ' + currentRatio + 'x,\n'
+          srcset += this.buildURL(path, queryParams) + ' ' + currentRatio + 'x,\n'
         }
 
         return srcset.slice(0,-2);

--- a/test/test-buildSrcSet.js
+++ b/test/test-buildSrcSet.js
@@ -387,6 +387,21 @@ describe('SrcSet Builder:', function describeSuite() {
                         assert(src.includes(`q=${QUALITY_OVERRIDE}`));
                     }
                 });
+
+                it('should not modify input params and should be idempotent', function testSpec() {
+                    var client = new ImgixClient({ domain: 'test.imgix.net' });
+                    var params = {};
+                    var srcsetOptions = { widths: [100] };
+                    var srcset1 = client.buildSrcSet('', params, srcsetOptions);
+                    var srcset2 = client.buildSrcSet('', params, srcsetOptions);
+
+                    // Show idempotent, ie. calling buildSrcSet produces the same result given
+                    // the same input-parameters.
+                    assert(srcset1 == srcset2);
+
+                    // Assert that the object remains unchanged.
+                    assert(Object.keys(params).length === 0 && params.constructor === Object);
+                });
             });
 
             describe('with an aspect ratio parameter provided', function describeSuite() {

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -223,11 +223,31 @@ describe('URL Builder:', function describeSuite() {
             assert.equal(expectation, result);
         });
 
+        it('does not modify its input-argument', function testSpec() {
+            var params = {
+                    w: 400,
+                    h: 300
+                },
+                expectation = '?w=400&h=300',
+                result = client._buildParams(params);
+
+            assert.equal(params.w, 400);
+            assert.equal(params.h, 300);
+            assert.equal(expectation, result);
+
+            var emptyParams = {};
+            var emptyResult = client._buildParams(emptyParams);
+
+            // Ensure the result is empty.
+            assert.equal(emptyResult, '');
+            assert(Object.keys(emptyParams).length === 0 && emptyParams.constructor === Object);
+        });
+
         it('includes an `ixlib` param if the `libraryParam` setting is truthy', function testSpec() {
             var params = {
                     w: 400
                 },
-                expectation = '?w=400&ixlib=test',
+                expectation = '?ixlib=test&w=400',
                 result;
 
             client.settings.libraryParam = 'test';
@@ -292,6 +312,63 @@ describe('URL Builder:', function describeSuite() {
                 result = client._signParams(path, '?w=400');
 
             assert.equal(expectation, result);
+        });
+    });
+
+    describe('Calling buildURL()', function describeSuite() {
+        var client,
+            path = 'images/1.png';
+
+        beforeEach(function setupClient() {
+            client = new ImgixClient({
+            domain: 'test.imgix.net',
+            includeLibraryParam: false
+            });
+        });
+
+        it('is an idempotent operation with empty args', function testSpec() {
+            var result1 = client.buildURL('', {});
+            var result2 = client.buildURL('', {});
+            assert.equal(result1, result2);
+        });
+
+
+        it('is an idempotent operation with args', function testSpec() {
+            var path = '/image/stöked.png';
+            var params = {w: 100};
+            var result1 = client.buildURL(path, params);
+            var result2 = client.buildURL(path, params);
+            var expected = 'https://test.imgix.net/image/st%C3%B6ked.png?w=100'
+            assert.equal(result1, expected);
+            assert.equal(result2, expected)
+        });
+
+
+        it('does not modify empty args', function testSpec() {
+            var path = '';
+            var params = {};
+            var result1 = client.buildURL(path, params);
+            var result2 = client.buildURL(path, params);
+            var expected = 'https://test.imgix.net/';
+
+
+            assert.equal(path, '');
+            assert.equal(expected, result1);
+            assert.equal(expected, result2)
+            assert(Object.keys(params).length === 0 && params.constructor === Object);
+        });
+
+        it('does not modify its args', function testSpec() {
+            var path = 'image/1.png';
+            var params = {w: 100};
+            var result1 = client.buildURL(path, params);
+            var result2 = client.buildURL(path, params);
+            var expected = 'https://test.imgix.net/image/1.png?w=100';
+
+            assert.equal(path, 'image/1.png');
+            assert.equal(result1, result2, expected);
+            assert(Object.keys(params).length === 1 && params.constructor === Object);
+            assert.equal(params.w, 100);
         });
     });
 });

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -230,17 +230,11 @@ describe('URL Builder:', function describeSuite() {
         });
 
         it('includes an `ixlib` param if the `libraryParam` setting is truthy', function testSpec() {
-            var params = {
-                    w: 400
-                },
-                expectation = '?ixlib=test&w=400',
-                result;
-
             client.settings.libraryParam = 'test';
 
-            result = client._buildParams(params);
+            var result = client._buildParams({});
 
-            assert.equal(expectation, result);
+            assert(result.match(/ixlib=test/));
         });
 
         it('url-encodes parameter keys properly', function testSpec() {

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -224,23 +224,9 @@ describe('URL Builder:', function describeSuite() {
         });
 
         it('does not modify its input-argument', function testSpec() {
-            var params = {
-                    w: 400,
-                    h: 300
-                },
-                expectation = '?w=400&h=300',
-                result = client._buildParams(params);
-
-            assert.equal(params.w, 400);
-            assert.equal(params.h, 300);
-            assert.equal(expectation, result);
-
             var emptyParams = {};
             var emptyResult = client._buildParams(emptyParams);
-
-            // Ensure the result is empty.
-            assert.equal(emptyResult, '');
-            assert(Object.keys(emptyParams).length === 0 && emptyParams.constructor === Object);
+            assert(Object.keys(emptyParams).length === 0);
         });
 
         it('includes an `ixlib` param if the `libraryParam` setting is truthy', function testSpec() {


### PR DESCRIPTION
The purpose of this PR is to ensure the `buildSrcSet` operation is
idempotent. Prior to this PR, code modified the input-parameters,
`params`, causing identical calls to `buildSrcSet` to produce different
results.

Now, the input `params` are copied into a new `queryParams` object and
this object is passed to callers requiring `params`. A test has been
written to show that the behavior has changed from the behavior detailed
in issue #158––the input `params` object remains unchanged after calling
`buildSrcSet` _and_ that calling `buildSrcSet` multiple times produces
the same result (given the same inputs).

I also ripgrep'd through the repo with `rg 'params.[:alpha:]'` and with
`rg 'params\['` to ensure `params` is never mutated (i.e. it never
appears on the left hand side of any expression).

Tests have been added to ensure that `_buildParams`:
- does not modify its input-argument

Tests have been added to ensure that calling `buildURL`:
- is an idempotent operation with empty args
- is an idempotent operation with args
- does not modify empty args
- does not modify its args (non-empty)

Tests have been added to ensure that `buildSrcSet`:
- does not modify input params and is idempotent

Closes #158 