### PR TITLE
refactor: push-and-join instead of concat-and-slice

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -158,7 +158,7 @@
     };
 
     ImgixClient.prototype._buildSrcSetPairs = function(path, params, options) {
-      var srcset = '';
+      var srcset = [];
       var currentWidth;
       var targetWidths;
       var customWidths = options.widths;
@@ -183,14 +183,14 @@
       for (var i = 0; i < targetWidths.length; i++) {
         currentWidth = targetWidths[i];
         queryParams.w = currentWidth;
-        srcset += this.buildURL(path, queryParams) + ' ' + currentWidth + 'w,\n';
+        srcset.push(this.buildURL(path, queryParams) + ' ' + currentWidth + 'w')
       }
 
-      return srcset.slice(0,-2);
+      return srcset.join(',\n')
     };
 
     ImgixClient.prototype._buildDPRSrcSet = function(path, params, options) {
-        var srcset = '';
+        var srcset = [];
         var targetRatios = [1, 2, 3, 4, 5];
         var disableVariableQuality = options.disableVariableQuality || false;
 
@@ -213,11 +213,10 @@
           if (!disableVariableQuality) {
             queryParams.q = quality || DPR_QUALITIES[currentRatio];
           }
-
-          srcset += this.buildURL(path, queryParams) + ' ' + currentRatio + 'x,\n'
+          srcset.push(this.buildURL(path, queryParams) + ' ' + currentRatio + 'x')
         }
 
-        return srcset.slice(0,-2);
+        return srcset.join(',\n');
     };
 
     // a cache to store memoized srcset width-pairs


### PR DESCRIPTION
The purpose of this PR is to make `._buildSrcSetPairs` and
`._buildDPRSrcSet` more direct. Before, this PR both functions
were concatenating strings within a loop. In both functions, the
last URL string to be generated includes `",\n"` which is sliced off
when the functions return.

Now, both functions generate/build URLs that are pushed onto the
`srcset` array. The URLs in the `srcset` array are then joined together
with `",\n"`.

This change was made in an attempt to improve the semantics. E.g.
"build URLs and join them with ',\n'" versus "build URLs, concatenate
them, and remove the extra ',\n' from the result".