### PR TITLE
chore: correct typescript-related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,6 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
-    "@types/node": {
-      "version": "12.12.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
-      "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==",
-      "dev": true
-    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
     "sinon": "9.2.0",
     "typescript": "^4.0.3",
     "uglify-js": "3.11.1"
-  },
-  "peerDependencies": {
-    "typescript": ">=1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,15 +19,13 @@
   },
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "@types/node": "12.12.31",
     "benchmark": "2.1.4",
     "mocha": "6.2.2",
     "sinon": "9.2.0",
-    "typescript": "4.0.3",
+    "typescript": "^4.0.3",
     "uglify-js": "3.11.1"
   },
   "peerDependencies": {
-    "typescript": "^3.6.3 || ^4.0.0",
-    "@types/node": "^12.7.8"
+    "typescript": ">=1.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "umd"
   },
-  "files": ["src/imgix-core-js.d.ts"],
-  "exclude": ["node_modules/**", "../../node_modules/**"]
+  "files": ["src/imgix-core-js.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,8 @@
 {
-    "compilerOptions": {
-        "target": "es2015",
-        "module": "umd",
-        "types": [
-            "node"
-        ]
-    },
-    "files": [
-        "src/imgix-core-js.d.ts"
-    ]
+  "compilerOptions": {
+    "target": "es5",
+    "module": "umd"
+  },
+  "files": ["src/imgix-core-js.d.ts"],
+  "exclude": ["node_modules/**", "../../node_modules/**"]
 }


### PR DESCRIPTION
I removed the peerDep on `@types/node` since it's not actually required, and updated the typescript peer dep to work with the oldest version of the type definitions that I could verify worked.

While creating this PR, I realised that we don't actually need a peer dependency on typescript since it a) forces non-TS consumers to install typescript as a dependency (otherwise they will have a persistent warning), and b) since our types work with TS versions all the way back to 1.5, we don't need to restrict the TS version that's installed, which makes the peer dependency redundant. Therefore I removed it.