### PR TITLE
chore: revert "fix(deps): update dependency js-base64 to v3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -404,9 +404,9 @@
       "dev": true
     },
     "js-base64": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.4.3.tgz",
-      "integrity": "sha512-SNMgYrBASovuSPsaZaoZ3g+u0ZLuSGGOIkTDT1u+WI4e8Ch7FnHdrvNqQm8CHGpoOhCmGKuDVr50Yw4VHMI/Eg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-yaml": {
       "version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "dist/imgix-core-js.js",
   "types": "dist/imgix-core-js.d.ts",
   "dependencies": {
-    "js-base64": "^3.0.0",
+    "js-base64": "^2.1.9",
     "md5": "^2.2.1"
   },
   "license": "BSD-2-Clause",


### PR DESCRIPTION
This reverts commit 87f87153e7de896b51064f53073c543502511c3a merged from #153.
The original update introduced a breaking change that cut off support to older browsers and ES environments. For now, we will err on the side of not cutting off support and attempt to mitigate this issue in a different way later on.