### PR TITLE
Fix repeated value

### DIFF
--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -244,10 +244,10 @@
         return 2 * Math.round(n / 2);
       };
 
-      var exact = minWidth;
+      var tempWidth = minWidth;
       while (resolutions[resolutions.length - 1] < maxWidth) {
-        exact *= 1 + (INCREMENT_PERCENTAGE * 2);
-        resolutions.push(Math.min(ensureEven(exact), maxWidth));
+        tempWidth *= 1 + (INCREMENT_PERCENTAGE * 2);
+        resolutions.push(Math.min(ensureEven(tempWidth), maxWidth));
       }
 
       this.targetWidthsCache[cacheKey] = resolutions;

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -224,10 +224,11 @@
 
     // returns an array of width values used during scrset generation
     ImgixClient.prototype._generateTargetWidths = function(widthTolerance, minWidth, maxWidth) {
-      var resolutions = [minWidth];
       var INCREMENT_PERCENTAGE = widthTolerance;
       var minWidth = Math.floor(minWidth);
       var maxWidth = Math.floor(maxWidth);
+
+      var resolutions = [minWidth];
 
       if (minWidth === maxWidth) {
         return resolutions;

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -224,10 +224,15 @@
 
     // returns an array of width values used during scrset generation
     ImgixClient.prototype._generateTargetWidths = function(widthTolerance, minWidth, maxWidth) {
-      var resolutions = [];
+      var resolutions = [minWidth];
       var INCREMENT_PERCENTAGE = widthTolerance;
       var minWidth = Math.floor(minWidth);
       var maxWidth = Math.floor(maxWidth);
+
+      if (minWidth === maxWidth) {
+        return resolutions;
+      }
+
       var cacheKey = INCREMENT_PERCENTAGE + '/' + minWidth + '/' + maxWidth;
 
       if (cacheKey in this.targetWidthsCache) {
@@ -238,13 +243,11 @@
         return 2 * Math.round(n / 2);
       };
 
-      var prev = minWidth;
-      while (prev < maxWidth) {
-        resolutions.push(ensureEven(prev));
-        prev *= 1 + (INCREMENT_PERCENTAGE * 2);
+      var exact = minWidth;
+      while (resolutions[resolutions.length - 1] < maxWidth) {
+        exact *= 1 + (INCREMENT_PERCENTAGE * 2);
+        resolutions.push(Math.min(ensureEven(exact), maxWidth));
       }
-
-      resolutions.push(maxWidth);
 
       this.targetWidthsCache[cacheKey] = resolutions;
 

--- a/test/test-buildSrcSet.js
+++ b/test/test-buildSrcSet.js
@@ -953,6 +953,20 @@ describe('SrcSet Builder:', function describeSuite() {
                     }, Error);
                 });
             });
+
+            describe('with widthTolerance, minWidth, and maxWidth set to promote an edge case', function describeSuite() {
+                var client = new ImgixClient({
+                    domain: 'testing.imgix.net',
+                    includeLibraryParam: false
+                })
+                var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.0999, minWidth: 1000, maxWidth: 1200});
+
+                it('should not repeat the largest width', function testSpec() {
+                    var srclist = srcset.split(",");
+                    assert.equal(parseInt(srclist[srclist.length - 1].split(" ")[1].slice(0,-1), 10), 1200);
+                    assert.notEqual(srclist[srclist.length - 2], srclist[srclist.length - 1]);
+                });
+            });
         });
     });
 });

--- a/test/test-buildSrcSet.js
+++ b/test/test-buildSrcSet.js
@@ -954,14 +954,14 @@ describe('SrcSet Builder:', function describeSuite() {
                 });
             });
 
-            describe('with widthTolerance, minWidth, and maxWidth set to promote an edge case', function describeSuite() {
+            describe('with widthTolerance, minWidth, and maxWidth values which have caused duplicate values in the past', function describeSuite() {
                 var client = new ImgixClient({
                     domain: 'testing.imgix.net',
                     includeLibraryParam: false
                 })
                 var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.0999, minWidth: 1000, maxWidth: 1200});
 
-                it('should not repeat the largest width', function testSpec() {
+                it('should not repeat the largest width when a running value just below maxWidth is reached', function testSpec() {
                     var srclist = srcset.split(",");
                     assert.equal(parseInt(srclist[srclist.length - 1].split(" ")[1].slice(0,-1), 10), 1200);
                     assert.notEqual(srclist[srclist.length - 2], srclist[srclist.length - 1]);


### PR DESCRIPTION
# Description

Two commits. One adds a failing test case for a bug where in certain conditions the largest value in the srcset list is repeated. The other commit fixes the bug. Full details are in the commit messages.

## Checklist: Bug Fix

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme **(n/a)**
- [ ] Update or add any necessary API documentation **(n/a)**
- [x] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

See the new test for an example failing case.

`buildSrcSet('image.jpg', {}, {widthTolerance: 0.0999, minWidth: 1000, maxWidth: 1200})` was outputting [1000, 1200, 1200].