### PR TITLE
Improve spacing between srcset widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ https://testing.imgix.net/image.jpg?w=100&s=e2e581a39c917bdee50b2f8689c30893 100
 https://testing.imgix.net/image.jpg?w=116&s=836e0bc15da2ad74af8130d93a0ebda6 116w,
 https://testing.imgix.net/image.jpg?w=134&s=688416d933381acda1f57068709aab79 134w,
                                             ...
-https://testing.imgix.net/image.jpg?w=7400&s=91779d82a0e1ac16db04c522fa4017e5 7400w,
+https://testing.imgix.net/image.jpg?w=7074&s=91779d82a0e1ac16db04c522fa4017e5 7074w,
 https://testing.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 8192w
 ```
 
@@ -259,11 +259,10 @@ console.log(srcset);
 In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:
 
 <!-- prettier-ignore-start -->
-
 ```html
 https://testing.imgix.net/image.jpg?w=100 100w,
-https://testing.imgix.net/image.jpg?w=140 140w,
-https://testing.imgix.net/image.jpg?w=196 196w,
+https://testing.imgix.net/image.jpg?w=136 136w,
+https://testing.imgix.net/image.jpg?w=188 188w,
 							...
 https://testing.imgix.net/image.jpg?w=8192 8192w
 ```
@@ -292,16 +291,16 @@ Will result in a smaller, more tailored srcset.
 
 ```html
 https://testing.imgix.net/image.jpg?w=500 500w,
-https://testing.imgix.net/image.jpg?w=580 580w,
-https://testing.imgix.net/image.jpg?w=672 672w,
-https://testing.imgix.net/image.jpg?w=780 780w,
-https://testing.imgix.net/image.jpg?w=906 906w,
-https://testing.imgix.net/image.jpg?w=1050 1050w,
-https://testing.imgix.net/image.jpg?w=1218 1218w,
-https://testing.imgix.net/image.jpg?w=1414 1414w,
-https://testing.imgix.net/image.jpg?w=1640 1640w,
-https://testing.imgix.net/image.jpg?w=1902 1902w,
-https://testing.imgix.net/image.jpg?w=2000 2000w
+https://testing.imgix.net/image.jpg?w=574 574w,
+https://testing.imgix.net/image.jpg?w=660 660w,
+https://testing.imgix.net/image.jpg?w=758 758w,
+https://testing.imgix.net/image.jpg?w=870 870w,
+https://testing.imgix.net/image.jpg?w=1000 1000w,
+https://testing.imgix.net/image.jpg?w=1148 1148w,
+https://testing.imgix.net/image.jpg?w=1320 1320w,
+https://testing.imgix.net/image.jpg?w=1516 1516w,
+https://testing.imgix.net/image.jpg?w=1742 1742w,
+https://testing.imgix.net/image.jpg?w=2000 2000w,
 ```
 
 Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_srcset: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -243,10 +243,26 @@
         return 2 * Math.round(n / 2);
       };
 
+      // Calculate the (probably non-integer) number of increments we'd make
+      // with the requested width tolerance to get from minWidth to maxWidth,
+      // and round it up to ensure the tolerance will be met or beaten.
+      // This formula is found by solving for numSteps the following identity:
+      //   minWidth * INCREMENT_RATIO ** numSteps == maxWidth
+      var numSteps = Math.ceil(Math.log(maxWidth / minWidth) / Math.log(INCREMENT_RATIO));
+
+      // Calculate an adjusted value for INCREMENT_RATIO
+      // such that numSteps would be an integer without the rounding used above.
+      // This is found by solving the same identity as above,
+      // but this time for INCREMENT_RATIO.
+      var adjustedIncrementRatio = Math.pow(maxWidth / minWidth, 1 / numSteps);
+      // Note that this will be NaN if numSteps was zero,
+      // but this is only when minWidth and maxWidth are equal,
+      // in which case adjustedIncrementRatio will not be used.
+
       var exact = minWidth;
       while (resolutions[resolutions.length - 1] < maxWidth) {
-        exact *= INCREMENT_RATIO;
-        resolutions.push(Math.min(ensureEven(exact), maxWidth));
+        exact *= adjustedIncrementRatio;
+        resolutions.push(Math.round(exact) === maxWidth ? maxWidth : ensureEven(exact));
       }
 
       this.targetWidthsCache[cacheKey] = resolutions;

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -225,7 +225,7 @@
     // returns an array of width values used during scrset generation
     ImgixClient.prototype._generateTargetWidths = function(widthTolerance, minWidth, maxWidth) {
       var resolutions = [minWidth];
-      var INCREMENT_PERCENTAGE = widthTolerance;
+      var INCREMENT_RATIO = 1 + (widthTolerance * 2);
       var minWidth = Math.floor(minWidth);
       var maxWidth = Math.floor(maxWidth);
 
@@ -233,7 +233,7 @@
         return resolutions;
       }
 
-      var cacheKey = INCREMENT_PERCENTAGE + '/' + minWidth + '/' + maxWidth;
+      var cacheKey = widthTolerance + '/' + minWidth + '/' + maxWidth;
 
       if (cacheKey in this.targetWidthsCache) {
         return this.targetWidthsCache[cacheKey];
@@ -245,7 +245,7 @@
 
       var exact = minWidth;
       while (resolutions[resolutions.length - 1] < maxWidth) {
-        exact *= 1 + (INCREMENT_PERCENTAGE * 2);
+        exact *= INCREMENT_RATIO;
         resolutions.push(Math.min(ensureEven(exact), maxWidth));
       }
 

--- a/src/imgix-core-js.js
+++ b/src/imgix-core-js.js
@@ -224,10 +224,15 @@
 
     // returns an array of width values used during scrset generation
     ImgixClient.prototype._generateTargetWidths = function(widthTolerance, minWidth, maxWidth) {
-      var resolutions = [];
+      var resolutions = [minWidth];
       var INCREMENT_PERCENTAGE = widthTolerance;
       var minWidth = Math.floor(minWidth);
       var maxWidth = Math.floor(maxWidth);
+
+      if (minWidth === maxWidth) {
+        return resolutions;
+      }
+
       var cacheKey = INCREMENT_PERCENTAGE + '/' + minWidth + '/' + maxWidth;
 
       if (cacheKey in this.targetWidthsCache) {
@@ -238,13 +243,11 @@
         return 2 * Math.round(n / 2);
       };
 
-      var prev = minWidth;
-      while (prev < maxWidth) {
-        resolutions.push(ensureEven(prev));
-        prev *= 1 + (INCREMENT_PERCENTAGE * 2);
+      var exact = minWidth;
+      while (resolutions[resolutions.length - 1] < maxWidth) {
+        exact *= 1 + (INCREMENT_PERCENTAGE * 2);
+        resolutions.push(Math.min(ensureEven(exact), maxWidth));
       }
-
-      resolutions.push(maxWidth);
 
       this.targetWidthsCache[cacheKey] = resolutions;
 

--- a/test/test-buildSrcSet.js
+++ b/test/test-buildSrcSet.js
@@ -953,6 +953,20 @@ describe('SrcSet Builder:', function describeSuite() {
                     }, Error);
                 });
             });
+
+            describe('with widthTolerance, minWidth, and maxWidth set to promote an edge case', function describeSuite() {
+                var client = new ImgixClient({
+                    domain: 'testing.imgix.net',
+                    includeLibraryParam: false
+                })
+                var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.0999, minWidth: 1000, maxWidth: 1200});
+
+                it('should not repeat the largest width', function testSpec() {
+                    var srclist = srcset.split(",");
+                    assert.equal(parseInt(srclist[srclist.length - 1].split(" ")[1].slice(0,-1), 10), 1200);
+                    assert.notEqual(srclist[srclist.length - 2], srclist[srclist.length - 1]);
+                });
+            });
         });
     });
 });

--- a/test/test-buildSrcSet.js
+++ b/test/test-buildSrcSet.js
@@ -21,10 +21,10 @@ describe('SrcSet Builder:', function describeSuite() {
                 });
 
                 it('should generate the expected default srcset pair values', function testSpec(){
-                    resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                                    328, 380, 442, 512, 594, 688, 798, 926,
-                                    1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                                    3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+                    resolutions = [100, 116, 134, 156, 180, 208, 242, 280,
+                                    324, 374, 434, 504, 582, 674, 782, 906,
+                                    1048, 1214, 1406, 1628, 1886, 2184, 2530,
+                                    2930, 3394, 3930, 4552, 5272, 6108, 7074, 8192];
                     srclist = srcset.split(",");
                     src = srclist.map(function (srcline){
                         return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
@@ -206,10 +206,10 @@ describe('SrcSet Builder:', function describeSuite() {
                 }).buildSrcSet('image.jpg', {h:100});
 
                 it('should generate the expected default srcset pair values', function testSpec(){
-                    resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                                    328, 380, 442, 512, 594, 688, 798, 926,
-                                    1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                                    3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+                    resolutions = [100, 116, 134, 156, 180, 208, 242, 280,
+                                    324, 374, 434, 504, 582, 674, 782, 906,
+                                    1048, 1214, 1406, 1628, 1886, 2184, 2530,
+                                    2930, 3394, 3930, 4552, 5272, 6108, 7074, 8192];
                     srclist = srcset.split(",");
                     src = srclist.map(function (srcline){
                         return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
@@ -416,10 +416,10 @@ describe('SrcSet Builder:', function describeSuite() {
                 });
 
                 it('should generate the expected default srcset pair values', function testSpec(){
-                    resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                                    328, 380, 442, 512, 594, 688, 798, 926,
-                                    1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                                    3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192];
+                    resolutions = [100, 116, 134, 156, 180, 208, 242, 280,
+                                    324, 374, 434, 504, 582, 674, 782, 906,
+                                    1048, 1214, 1406, 1628, 1886, 2184, 2530,
+                                    2930, 3394, 3930, 4552, 5272, 6108, 7074, 8192];
                     srclist = srcset.split(",");
                     src = srclist.map(function (srcline){
                         return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
@@ -701,7 +701,7 @@ describe('SrcSet Builder:', function describeSuite() {
                 });
 
                 it('should generate the expected default srcset pair values', function testSpec(){
-                    resolutions = [500, 580, 672, 780, 906, 1050, 1218, 1414, 1640, 1902, 2000];
+                    resolutions = [500, 574, 660, 758, 870, 1000, 1148, 1320, 1516, 1742, 2000];
                     srclist = srcset.split(",");
                     src = srclist.map(function (srcline){
                         return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
@@ -821,7 +821,7 @@ describe('SrcSet Builder:', function describeSuite() {
                 });
 
                 it('should generate the expected default srcset pair values', function testSpec(){
-                    resolutions = [100, 140, 196, 274, 384, 538, 752, 1054, 1476, 2066, 2892, 4050, 5670, 7938, 8192];
+                    resolutions = [100, 136, 188, 258, 352, 482, 660, 906, 1240, 1698, 2326, 3186, 4366, 5980, 8192];
                     srclist = srcset.split(",");
                     src = srclist.map(function (srcline){
                         return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
@@ -959,12 +959,34 @@ describe('SrcSet Builder:', function describeSuite() {
                     domain: 'testing.imgix.net',
                     includeLibraryParam: false
                 })
-                var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.0999, minWidth: 1000, maxWidth: 1200});
 
                 it('should not repeat the largest width', function testSpec() {
+                    // This failed before the increment ratio logic changed
+                    var srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.0999, minWidth: 1000, maxWidth: 1200});
                     var srclist = srcset.split(",");
                     assert.equal(parseInt(srclist[srclist.length - 1].split(" ")[1].slice(0,-1), 10), 1200);
                     assert.notEqual(srclist[srclist.length - 2], srclist[srclist.length - 1]);
+
+                    // The following case leads to 1439.999... being produced at
+                    // the last step (presumably due to floating point error),
+                    // and so would fail if rounding is not performed during the
+                    // check against maxWidth
+                    srcset = client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.1, minWidth: 320, maxWidth: 1440});
+                    srclist = srcset.split(",");
+                    assert.equal(parseInt(srclist[srclist.length - 1].split(" ")[1].slice(0,-1), 10), 1440);
+                    assert.notEqual(srclist[srclist.length - 2], srclist[srclist.length - 1]);
+                });
+
+                it('correctly handles an odd maxWidth', function testSpec() {
+                    var srcset = client.buildSrcSet('image.jpg', {}, {minWidth: 1000, maxWidth: 1001});
+                    resolutions = [1000, 1001];
+                    var srclist = srcset.split(",");
+                    src = srclist.map(function (srcline){
+                        return parseInt(srcline.split(" ")[1].slice(0,-1), 10);
+                    });
+                    for (var i = 0; i < srclist.length; i++) {
+                        assert.equal(src[i], resolutions[i]);
+                    }
                 });
             });
         });


### PR DESCRIPTION
# Description

In this changeset I derive an improved increment ratio for srcset generation from the width tolerance.

Before this patch the widths increase at a regularly-exponential rate until the second-largest width, then the largest width is equal to the maximum width. In all but some very particular cases this will mean the largest two widths are much more closely spaced than the others, in terms of the exponential scale at least. It is possible to have candidate widths of 8190 and 8192 pixels, for example, if the right minWidth, maxWidth, and widthTolerance values are chosen. (Obviously this is an extreme case.)

## Checklist: Bug Fix

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR **(no brand-new tests, but adjusted affected existing ones and added a new clause to the test I added as part of #184 since the new code is no longer susceptible to the previously-failing case)**
- [x] Update the readme
- [ ] Update or add any necessary API documentation **(n/a)**
- [x] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

I think the changes to the tests already cover this, but as a realistic example where the difference is easier to see:

    client.buildSrcSet('image.jpg', {}, {widthTolerance: 0.1, minWidth: 320, maxWidth: 1440})

- Before the change:
  320,384,460,552,664,796,956,1146,1376,1440

      1600 +----------------------------------------------------------------------+
           |             +             +              +             +             |
           |                                                                      |
      1400 |-+                                                             A    +-|
           |                                                        A             |
           |                                                                      |
           |                                                                      |
      1200 |-+                                               A                  +-|
           |                                                                      |
           |                                                                      |
      1000 |-+                                                                  +-|
           |                                          A                           |
           |                                                                      |
       800 |-+                                 A                                +-|
           |                                                                      |
           |                           A                                          |
       600 |-+                                                                  +-|
           |                    A                                                 |
           |                                                                      |
           |             A                                                        |
       400 |-+    A                                                             +-|
           |                                                                      |
           |             +             +              +             +             |
           +----------------------------------------------------------------------+

  (this plot looks more bumpy than it really is due to ascii; the only important part is the sudden change in direction for the last value)

- After the change:
  320,378,448,528,624,738,872,1030,1218,1440

      1600 +----------------------------------------------------------------------+
           |             +             +              +             +             |
           |                                                                      |
      1400 |-+                                                             A    +-|
           |                                                                      |
           |                                                                      |
           |                                                        A             |
      1200 |-+                                                                  +-|
           |                                                                      |
           |                                                 A                    |
      1000 |-+                                                                  +-|
           |                                                                      |
           |                                          A                           |
       800 |-+                                                                  +-|
           |                                   A                                  |
           |                                                                      |
       600 |-+                         A                                        +-|
           |                                                                      |
           |                    A                                                 |
           |             A                                                        |
       400 |-+    A                                                             +-|
           |                                                                      |
           |             +             +              +             +             |
           +----------------------------------------------------------------------+

## Note

I've built this on top of #184 since that was a bug I found while writing this and they touch some of the same code. As such, you may not need to review all commits; only the last two are strictly relevant. I can rebase it to be straight on top of main if you like.