### PR TITLE
test: run mocha on esm instead of cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublish": "npm run build && npm run compile",
     "pretest": "npm run build",
     "pretty": "prettier --write '{src,test}/**/*.js'",
-    "test": "mocha ./test/build/*.cjs",
+    "test": "mocha ./test/",
     "test:performance": "mocha test/performance/*.js"
   },
   "files": [


### PR DESCRIPTION
The purpose of this PR is to debug module testing in a node environment (for CI).