### PR TITLE
feat: enforce 0.01 lower bound for widthTolerance

### DIFF
--- a/src/validators.mjs
+++ b/src/validators.mjs
@@ -40,9 +40,9 @@ export function validateRange(min, max) {
 }
 
 export function validateWidthTolerance(widthTolerance) {
-  if (typeof widthTolerance != 'number' || widthTolerance <= 0) {
+  if (typeof widthTolerance != 'number' || widthTolerance < 0.01) {
     throw new Error(
-      'The srcset widthTolerance argument can only be passed a positive scalar number',
+      'The srcset widthTolerance must be a number greater than or equal to 0.01',
     );
   }
 }

--- a/test/test-buildSrcSet.mjs
+++ b/test/test-buildSrcSet.mjs
@@ -1079,9 +1079,20 @@ describe('SrcSet Builder:', function describeSuite() {
             domain: 'testing.imgix.net',
           }).buildSrcSet('image.jpg', {}, { widthTolerance: 999999.999 });
 
-          const actualLength = srcset.split(',').length;
+          const srcsetSplit = srcset.split(',');
+          const actualLength = srcsetSplit.length;
+
+          const srcsetMin = Number.parseFloat(
+            srcsetSplit[0].split(' ')[1].slice(0, -1),
+          );
+
+          const srcsetMax = Number.parseFloat(
+            srcsetSplit[srcsetSplit.length - 1].split(' ')[1].slice(0, -1),
+          );
 
           assert.strictEqual(actualLength, 2);
+          assert.strictEqual(srcsetMin, 100);
+          assert.strictEqual(srcsetMax, 8192);
         });
 
         it('memoizes generated srcset width pairs', function testSpec() {

--- a/test/test-buildSrcSet.mjs
+++ b/test/test-buildSrcSet.mjs
@@ -1074,6 +1074,16 @@ describe('SrcSet Builder:', function describeSuite() {
           }, Error);
         });
 
+        it('produces srcset with min and max widths when widthTolerance is large', function testSpec() {
+          const srcset = new ImgixClient({
+            domain: 'testing.imgix.net',
+          }).buildSrcSet('image.jpg', {}, { widthTolerance: 999999.999 });
+
+          const actualLength = srcset.split(',').length;
+
+          assert.strictEqual(actualLength, 2);
+        });
+
         it('memoizes generated srcset width pairs', function testSpec() {
           let DEFAULT_MIN_WIDTH = 100;
           let DEFAULT_MAX_WIDTH = 8192;

--- a/test/test-validators.mjs
+++ b/test/test-validators.mjs
@@ -85,9 +85,9 @@ describe('Validators:', function () {
       });
     });
 
-    it('throws if widthTolerance is <= 0', () => {
+    it('throws if widthTolerance is < 0.01', () => {
       assert.throws(() => {
-        validateWidthTolerance(0);
+        validateWidthTolerance(0.00999999999);
       });
     });
 
@@ -103,8 +103,17 @@ describe('Validators:', function () {
       });
     });
 
-    // TODO: should fail.
-    it('widthTolerance === 0.001', () => {});
+    it('does not throw on valid lower bound of 0.01', () => {
+      assert.doesNotThrow(() => {
+        validateWidthTolerance(0.01);
+      });
+    });
+
+    it('does not throw when passed a large value', () => {
+      assert.doesNotThrow(() => {
+        validateWidthTolerance(99999999.99);
+      });
+    });
   });
 
   describe('Testing validateVariableQuality', function () {


### PR DESCRIPTION
The purpose of this PR is to enforce a lower bound on `widthTolerance`.
Prior, `widthTolerance` was expected to be greater than zero. However,
accepting a number like `0.000000001` here can do more harm than good.
We don't expect that such a number represents an actual use-case,
rather, we're enforcing this lower bound to keep defaults sensible and
help users guard against undesirable/accidental input.

Now, we enforce a lower bound of `0.01` on `widthTolerance`. This is also
pretty lenient, e.g. with the min/max width defaults set and setting the width
tolerance down to `0.01` (to one percent) we can make a srcset with 224
image URLs in it where the widths progress like `100, 102, 104, 106,
108, 110...`.