### PR TITLE
feat: create a DPR srcset when a fixed height is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ https://testing.imgix.net/image.jpg?w=8192&s=59eb881b618fed314fe30cf9e3ec7b00 81
 
 #### Fixed Image Rendering
 
-In cases where enough information is provided about an image's dimensions, `buildSrcSet()` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `buildSrcSet()` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
+Specifying either a `w` or a `h` parameter to `buildSrcSet()` will create a DPR-based srcset. This DPR-based srcset allows for the fixed-sized image to be served at different resolutions (i.e. at different pixel densities).
 
 ```js
 var client = new ImgixClient({

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -103,9 +103,9 @@ export default class ImgixClient {
   }
 
   buildSrcSet(path, params = {}, options = {}) {
-    const { w, h, ar } = params;
+    const { w, h } = params;
 
-    if (w || (h && ar)) {
+    if (w || h) {
       return this._buildDPRSrcSet(path, params, options);
     } else {
       return this._buildSrcSetPairs(path, params, options);

--- a/test/test-buildSrcSet.mjs
+++ b/test/test-buildSrcSet.mjs
@@ -254,21 +254,8 @@ describe('SrcSet Builder:', function describeSuite() {
           });
         });
 
-        it('should generate the expected default srcset pair values', function testSpec() {
-          assertCorrectWidthDescriptors(srcset, RESOLUTIONS);
-        });
-
-        it('should return the expected number of `url widthDescriptor` pairs', function testSpec() {
-          assert.strictEqual(srcset.split(',').length, 31);
-        });
-
-        it('should not exceed the bounds of [100, 8192]', function testSpec() {
-          assertMinMaxWidthBounds(srcset, 100, 8192);
-        });
-
-        // a 17% testing threshold is used to account for rounding
-        it('should not increase more than 17% every iteration', function testSpec() {
-          assertWidthsIncreaseByTolerance(srcset, 0.17);
+        it('creates a DPR srcset with default DPR values', function testSpec() {
+          assertIncludesDefaultDprParamAndDescriptor(srcset);
         });
 
         it('should correctly sign each URL', function testSpec() {


### PR DESCRIPTION
The purpose of this PR is to ensure we create a DPR-based srcset when
a fixed height, `h`, is specified. Prior, we required that a `h` and
an aspect ratio (`ar`) be passed. Now, we require that only  a `w` or
`h` be specified to trigger a DPR-based srcset to be created.

Closes #177
