### PR TITLE
refactor: improve target widths generation

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -165,25 +165,35 @@ export default class ImgixClient {
 
   // returns an array of width values used during srcset generation
   _generateTargetWidths(widthTolerance, minWidth, maxWidth) {
-    const INCREMENT_PERCENTAGE = widthTolerance;
-    const _minWidth = Math.floor(minWidth);
-    const _maxWidth = Math.floor(maxWidth);
-    const cacheKey = INCREMENT_PERCENTAGE + '/' + _minWidth + '/' + _maxWidth;
+    const minW = Math.floor(minWidth);
+    const maxW = Math.floor(maxWidth);
+    const cacheKey = widthTolerance + '/' + minW + '/' + maxW;
 
-    const resolutions = [_minWidth];
-
-    if (minWidth === maxWidth) {
-      return resolutions;
-    }
-
+    // First, check the cache.
     if (cacheKey in this.targetWidthsCache) {
       return this.targetWidthsCache[cacheKey];
     }
 
-    let tempWidth = _minWidth;
-    while (resolutions[resolutions.length - 1] < _maxWidth) {
-      tempWidth *= 1 + INCREMENT_PERCENTAGE * 2;
-      resolutions.push(Math.min(Math.round(tempWidth), _maxWidth));
+    if (minW === maxW) {
+      return [minW];
+    }
+
+    const resolutions = [];
+    let currentWidth = minW;
+    while (currentWidth < maxW) {
+      // While the currentWidth is less than the maxW, push the rounded
+      // width onto the list of resolutions.
+      resolutions.push(Math.round(currentWidth));
+      currentWidth *= 1 + widthTolerance * 2;
+    }
+
+    // At this point, the last width in resolutions is less than the
+    // currentWidth that caused the loop to terminate. This terminating
+    // currentWidth is greater than or equal to the maxW. We want to
+    // to stop at maxW, so we make sure our maxW is larger than the last
+    // width in resolutions before pushing it (if it's equal we're done).
+    if (resolutions[resolutions.length - 1] < maxW) {
+      resolutions.push(maxW);
     }
 
     this.targetWidthsCache[cacheKey] = resolutions;


### PR DESCRIPTION
Prior, this function performed an array access, property access, and
a comparison in the loop condition. Now, this has been reduced to a
single comparison. Prior, this function made an additional function
call/comparison in the body (i.e. `Math.min`) on every iteration. Now,
that has been removed as well.

Prior, this function attempted to return a list resolutions before
checking the cache (i.e. `[minW]`). Now, we check the cache first.

Now, when the loop terminates we know that the last width to be pushed
is less than the currentWidth that caused the loop condition to fail
and its value is greater than or equal to `maxW`. We want to stop at
`maxW` exactly so we push it if it's less than the last resolution.
