### PR TITLE
fix: percent encode plus signs in path components

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -96,7 +96,7 @@ export default class ImgixClient {
     } else {
       // Use de/encodeURI if we think the path is just a path,
       // so it leaves legal characters like '/' and '@' alone
-      _path = encodeURI(_path).replace(/[#?:]/g, encodeURIComponent);
+      _path = encodeURI(_path).replace(/[#?:+]/g, encodeURIComponent);
     }
 
     return '/' + _path;

--- a/test/test-buildURL.mjs
+++ b/test/test-buildURL.mjs
@@ -339,5 +339,12 @@ describe('URL Builder:', function describeSuite() {
       assert.strictEqual(Object.keys(params).length, 1);
       assert.strictEqual(params.constructor, Object);
     });
+
+    it('correctly encodes plus signs (+) in paths', function testSpec() {
+      const actual = client.buildURL('&$+,:;=?@#.jpg', {});
+      const expected = 'https://test.imgix.net/&$%2B,%3A;=%3F@%23.jpg';
+
+      assert.strictEqual(actual, expected);
+    });
   });
 });


### PR DESCRIPTION
While testing encoding behavior across the SDKs I found a failure to
encode this path: `"&$+,:;=?@#.jpg"`. Prior to this PR our encoding step
didn't replace plus signs (+). Now we replace plus signs with `%2B`.

To see that the original encoding step fails, replace the domain of this
URL `'https://test.imgix.net/&$+,%3A;=%3F@%23.jpg'` to see that it 404s.

Likewise, you can replace the domain of the this correctly encoded URL:
`'https://test.imgix.net/&$%2B,%3A;=%3F@%23.jpg'` to see that it 200s
(and the image is displayed).

For reference see [RF3986 - Appendix B](https://tools.ietf.org/html/rfc3986#appendix-B).