### PR TITLE
feat: option to sort URL parameters alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following options can be used when creating an instance of `ImgixClient`:
 - **`includeLibraryParam`:** Boolean. Specifies whether the constructed URLs will include an [`ixlib` parameter](#what-is-the-ixlib-param-on-every-request). Defaults to `true`.
 - **`secureURLToken`:** String. When specified, this token will be used to sign images. Read more about securing images [on the imgix Docs site](https://docs.imgix.com/setup/securing-images). Defaults to `null`.
   - :warning: *The `secureURLToken` option should only be used in server-side applications to prevent exposing your secure token.* :warning:
+- **`sortParams`:** Boolean. Specifies whether the constructed URLs parameters should be sorted alphabetically. Defaults to `false`.
 
 
 ## API

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,4 +26,5 @@ export const DEFAULT_OPTIONS = {
   includeLibraryParam: true,
   urlPrefix: 'https://',
   secureURLToken: null,
+  sortParams: false,
 };

--- a/test/test-buildURL.js
+++ b/test/test-buildURL.js
@@ -396,11 +396,11 @@ describe('URL Builder:', function describeSuite() {
         {
           encoder: (path) => encodeURI(path).replace("'", "%27")
         }
-      )
+      );
 
-      const expected = 'https://test.imgix.net/unsplash/walrus.jpg?txt=test!(%27)&txt-color=000&txt-size=400&txt-font=Avenir-Black&txt-x=800&txt-y=600'
+      const expected = 'https://test.imgix.net/unsplash/walrus.jpg?txt=test!(%27)&txt-color=000&txt-size=400&txt-font=Avenir-Black&txt-x=800&txt-y=600';
 
-      assert.strictEqual(actual, expected)
+      assert.strictEqual(actual, expected);
     });
 
     it('can custom encode the parameter value based on the parameter key', () => {
@@ -409,6 +409,27 @@ describe('URL Builder:', function describeSuite() {
       const result = client._buildParams(params, { encoder: (value, key) => key && key.substr(-2) === '64' ? Base64.encodeURI(value) : value.replace(" ", "+") });
 
       assert.strictEqual(result, expectation);
+    });
+
+    it('sorts parameters if the `sortParams` setting is truthy', () => {
+      client.settings.sortParams = true;
+
+      const actual = client.buildURL(
+        "unsplash/walrus.jpg",
+        {
+          txt64: 'base64',
+          txt: 'text',
+          'txt-color': '000',
+          'txt-size': 400,
+          'txt-x': 800,
+          'txt-y': 600,
+          'txt-font': 'Avenir-Black',
+        }
+      );
+
+      const expected = 'https://test.imgix.net/unsplash/walrus.jpg?txt=text&txt-color=000&txt-font=Avenir-Black&txt-size=400&txt-x=800&txt-y=600&txt64=YmFzZTY0';
+
+      assert.strictEqual(actual, expected);
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,7 @@ declare class ImgixClient {
     secureURLToken?: string;
     useHTTPS?: boolean;
     includeLibraryParam?: boolean;
+    sortParams?: boolean;
   });
 
   buildURL(
@@ -53,12 +54,12 @@ export interface SrcSetOptions {
 }
 
 export interface _sanitizePathOptions {
-  disablePathEncoding?: boolean,
-  encoder?: (path: string) => string
+  disablePathEncoding?: boolean;
+  encoder?: (path: string) => string;
 }
 
 export interface _buildParamsOptions {
-  encoder?: (value: string, key?: string) => string
+  encoder?: (value: string, key?: string) => string;
 }
 
 export default ImgixClient;


### PR DESCRIPTION
## Description

PHP library currently [sorts query parameters](https://github.com/imgix/imgix-php/blob/b42231e6e249e57592c474b08f79fe67d34615d8/src/UrlHelper.php#L78). This means that the URLs generated by PHP and JavaScript might differ. This could cause issues, especially with image preloading. For instance, the URL in an `img` tag might not match the URL in a `link` tag, even though both point to the same image.

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).
- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
